### PR TITLE
sync: Add origin additions before Claude-native rework

### DIFF
--- a/.claude/agents/merge-decider.md
+++ b/.claude/agents/merge-decider.md
@@ -122,12 +122,19 @@ Compute `REQ Readiness` as:
   | Failure Mode | Target Flow | Target Agent/Station | Task |
   |--------------|-------------|---------------------|------|
   | Reward Hacking (test deletion) | Flow 3 | `code-implementer` | "Restore deleted tests" |
-  | Contract Violation | Flow 3 | `code-implementer` | "Fix API implementation to match contract" |
+  | Contract Violation (impl bug) | Flow 3 | `code-implementer` | "Fix API implementation to match contract" |
+  | Contract Violation (contract wrong) | Flow 2 | `interface-designer` | "Update contract to match intended behavior" |
   | Missing Spec/Contract | Flow 2 | `interface-designer` | "Define the missing contract" |
   | Security Finding (code fix) | Flow 3 | `fixer` | "Remediate security issue" |
   | Security Finding (design flaw) | Flow 2 | `design-optioneer` | "Propose secure alternative" |
   | Coverage Gap | Flow 3 | `test-author` | "Add missing test coverage" |
   | Format/Lint Drift | Flow 3 | `fixer` | "Apply formatting fixes" |
+
+  **Law 7 consideration (Local Resolution First):**
+  * Before bouncing to a previous flow, consider whether the issue can be resolved locally using specialist agents
+  * **Try local resolution first:** Call `design-optioneer`, `adr-author`, or `impact-analyzer` for surgical fixes within the current flow
+  * **BOUNCE only when:** The specialists agree the issue cannot be resolved locally, requires stakeholder decisions, or spans multiple flows
+  * The bar for flow-level bounces is high—2-3 surgical agent calls are almost always cheaper than a full context switch
 
   * Default: **Build (Flow 3)** for implementation/tests/contracts/security/coverage/receipt issues.
   * Use **Plan (Flow 2)** only for design/architecture flaws that cannot be fixed with code changes.


### PR DESCRIPTION
## Summary

Sync valuable additions from `demo-swarm` origin into `demo-swarm-swarm` before the larger Claude-native alignment rework.

## What This Adds

These additions from origin align with the fix-forward mentality:

### merge-decider.md
- **Law 7 consideration** (local resolution first) - try specialist agents before bouncing to previous flows
- **Contract violation split** - distinguishes "impl bug" vs "contract wrong" for better routing

### flow-3-build.md  
- **Staging-first order** in Save Game Routine - the sanitizer must scan what's actually staged
- **Explanation** of why order matters

## Context

This ensures both repos (`demo-swarm` and `demo-swarm-swarm`) are aligned before the larger Claude-native alignment work is rebased and PR'd here.

The larger rework will:
- Remove harness-era Machine Summary blocks
- Convert to prose-based handoffs throughout
- Make critics do real work instead of enum emission

These additions should be preserved through that rework.

## Files Changed

- `.claude/agents/merge-decider.md` (+9 lines)
- `.claude/commands/flow-3-build.md` (+7 lines)