### PR TITLE
docs/rules: completion discipline consistency

### DIFF
--- a/.claude/commands/flow-3-build.md
+++ b/.claude/commands/flow-3-build.md
@@ -20,6 +20,36 @@ This is the Stubborn Loop: implement → test → critique → fix → repeat un
 
 Flow 3 grabs external feedback (PR, CI, bots) when available to unblock the build. Route CRITICAL blockers immediately. Defer the full worklist to Flow 4.
 
+## Convergence Discipline
+
+**The loop ends for exactly two reasons:**
+
+1. **Converged** — Evidence panel green (tests pass, critics satisfied, evidence fresh)
+2. **Budget exhausted** — External constraint. Complete what you have, document where you are, finish UNVERIFIED.
+
+Everything else is "keep grinding."
+
+### Routing to Unstick
+
+**Counts are not conditions. Signal is.**
+
+"We've run 3 times" → run it again. A count alone justifies nothing.
+
+- **Stagnation** (same failure, no new signal) → route to a different agent, change approach. This is orchestration, not stopping.
+- **Oscillation** (code toggling between states) → break the cycle by routing differently.
+
+The orchestrator's job is to keep things moving. When progress stalls, route to unstick.
+
+### No Early Exit
+
+"Done" is mechanical, not felt:
+- Agent claims done → verify with test-executor
+- Test-executor passes → verify with critics
+- Critics satisfied → AC is complete
+- Any step fails → route and retry, change approach, keep going
+
+**"3 tries then proceed as if done" is forbidden.** 3 tries → run it again. Still failing → try a different approach. Budget exhausted → complete UNVERIFIED with honest state.
+
 ## Working Directory + Paths
 
 - All commands run from **repo root**
@@ -101,15 +131,19 @@ Read `.runs/<run-id>/plan/ac_matrix.md` for the ordered AC list.
 The critic's job is to *find the flaw*. The writer's job is to *fix it*. This is rigorous verification.
 
 ```
-writer → critic → [if more work needed] → writer → critic → ... → [proceed]
+writer → critic → [if more work needed] → writer → critic → ... → [converged]
 ```
 
 Route on the critic's handoff:
 - If the critic recommends improvements → run the writer with their feedback
-- If the critic says "proceed" or "ready" → move forward
-- If the critic says "no further improvement possible" → proceed with documented issues
+- If the critic says "proceed" or "ready" → move forward (converged)
+- If the critic says "no further improvement possible" → proceed with documented issues (partial convergence)
 
-Trust the critic's judgment on when work is done.
+**When not making progress:**
+- Same critique repeated → route to a different agent or change approach (unstick, don't stop)
+- Critic alternating between contradictory recommendations → break the cycle by routing differently
+
+The orchestrator's job is to keep things moving. Stagnation triggers routing, not stopping.
 
 **Handling Logic Mismatches (Law 7: Local Resolution):**
 
@@ -205,7 +239,11 @@ After all ACs complete:
 
 **Reseal-if-modified:** If the self-reviewer identifies issues that require fixes (and you run `fixer`, `code-implementer`, or `test-author` to address them), you must call `build-cleanup` again to regenerate `build_receipt.json` before the final seal. The receipt must reflect the final state of code and tests, not an intermediate state.
 
-**Non-convergence guard:** Reseal at most twice. If `modified_files` persists after the second reseal pass, proceed with the receipt as-is and document the non-convergent state in `build_receipt.json.observations[]`. Do not enter an infinite reseal loop.
+**Reseal limit:** Reseal at most twice. If `modified_files` persists after the second reseal pass:
+- Document the state in `build_receipt.json.observations[]`
+- Route to Flow 4 (Review) to address remaining issues — this is routing, not giving up
+- Do NOT enter an infinite reseal loop
+- Do NOT claim the build is complete when it is not converged
 
 ### Step 8: Flow Boundary Harvest
 
@@ -307,12 +345,17 @@ Plus code/test changes in project-defined locations.
 
 ## Flow Outcomes
 
-- **VERIFIED**: Tests pass, diff is honest, ready for Flow 4
-- **PARTIAL**: Progress made, documented honestly, flow is resumable
-- **UNVERIFIED**: Gaps documented, proceed with blockers
+- **VERIFIED**: Tests pass, diff is honest, evidence panel green, ready for Flow 4
+- **PARTIAL**: Progress made, documented honestly, flow is resumable (valid checkpoint)
+- **UNVERIFIED**: External constraint hit or gaps exist, checkpointed with honest state
 - **CANNOT_PROCEED**: Mechanical failure (IO/permissions/tooling)
 
 All of these except CANNOT_PROCEED are valid outcomes. An honest PARTIAL is better than a false VERIFIED.
+
+**Key distinction:**
+- VERIFIED = converged (evidence says done)
+- UNVERIFIED = not converged, but checkpointed (artifacts written, state captured, resumable)
+- False VERIFIED (claiming done when not) = system failure
 
 ## TodoWrite (copy exactly)
 

--- a/.claude/commands/flow-3-build.md
+++ b/.claude/commands/flow-3-build.md
@@ -22,10 +22,12 @@ Flow 3 grabs external feedback (PR, CI, bots) when available to unblock the buil
 
 ## Convergence Discipline
 
-**The loop ends for exactly two reasons:**
+**Build completes with one of two statuses:**
 
-1. **Converged** — Evidence panel green (tests pass, critics satisfied, evidence fresh)
-2. **Budget exhausted** — External constraint. Complete what you have, document where you are, finish UNVERIFIED.
+| Status | When | What It Means |
+|--------|------|---------------|
+| **VERIFIED** | Evidence says done | Tests pass, critics satisfied, evidence fresh |
+| **UNVERIFIED** | External constraint hit | Artifacts written, state captured, resumable |
 
 Everything else is "keep grinding."
 
@@ -239,10 +241,10 @@ After all ACs complete:
 
 **Reseal-if-modified:** If the self-reviewer identifies issues that require fixes (and you run `fixer`, `code-implementer`, or `test-author` to address them), you must call `build-cleanup` again to regenerate `build_receipt.json` before the final seal. The receipt must reflect the final state of code and tests, not an intermediate state.
 
-**Reseal limit:** Reseal at most twice. If `modified_files` persists after the second reseal pass:
+**Reseal routing:** After two reseal passes, if `modified_files` persists, this lane isn't converging—route out:
 - Document the state in `build_receipt.json.observations[]`
-- Route to Flow 4 (Review) to address remaining issues — this is routing, not giving up
-- Do NOT enter an infinite reseal loop
+- Route to Flow 4 (Review) to address remaining issues
+- The reseal lane stops; the flow continues via Review
 - Do NOT claim the build is complete when it is not converged
 
 ### Step 8: Flow Boundary Harvest

--- a/.claude/commands/flow-3-build.md
+++ b/.claude/commands/flow-3-build.md
@@ -26,8 +26,8 @@ Flow 3 grabs external feedback (PR, CI, bots) when available to unblock the buil
 
 | Status | When | What It Means |
 |--------|------|---------------|
-| **VERIFIED** | Evidence says done | Tests pass, critics satisfied, evidence fresh |
-| **UNVERIFIED** | External constraint hit | Artifacts written, state captured, resumable |
+| **VERIFIED** | Evidence says done | Build stations complete (tests pass, critics satisfied), evidence fresh |
+| **UNVERIFIED** | External constraint hit | Checkpointed: artifacts written, state captured, resumable (continue via routing) |
 
 Everything else is "keep grinding."
 
@@ -50,7 +50,7 @@ The orchestrator's job is to keep things moving. When progress stalls, route to 
 - Critics satisfied → AC is complete
 - Any step fails → route and retry, change approach, keep going
 
-**"3 tries then proceed as if done" is forbidden.** 3 tries → run it again. Still failing → try a different approach. Budget exhausted → complete UNVERIFIED with honest state.
+**"3 tries then proceed as if done" is forbidden.** 3 tries → run it again. Still failing? Try a different approach. Budget exhausted → complete UNVERIFIED with honest state.
 
 ## Working Directory + Paths
 

--- a/.claude/commands/flow-5-gate.md
+++ b/.claude/commands/flow-5-gate.md
@@ -34,6 +34,39 @@ You are the PM orchestrating Flow 5 of the SDLC swarm. Your team of specialist a
 - Decide: MERGE / BOUNCE (with reason for human-review vs fix-required)
 - **Runner-bounded fix-forward lane** for deterministic mechanical drift (fmt/import/whitespace/docs) when `gate-fixer` says it is safe and resealable
 
+## Convergence Discipline
+
+**Gate runs to completion. It never stops mid-execution.**
+
+A Gate ends with one of two statuses:
+
+| Status | When | What It Means |
+|--------|------|---------------|
+| **VERIFIED** | Evidence says done | All verification agents pass, merge-decider renders verdict, evidence is fresh |
+| **UNVERIFIED** | External constraint hit | Artifacts written, state captured, resumable—BOUNCE with reason |
+
+External constraints are rare (budget/access/authority). Everything else is routing.
+
+### What "Pass" Means in Gate
+
+| Condition | Status |
+|-----------|--------|
+| Agent reports clean, evidence exists | PASS |
+| Agent reports issues, evidence exists | FAIL (route to fix or BOUNCE) |
+| Agent reports clean, no evidence | UNKNOWN (not PASS) |
+| Agent cannot run | BLOCKED (mechanical failure) |
+
+**UNKNOWN is not PASS.** A verification agent that doesn't produce evidence has not verified.
+
+### Routing to Unstick in Gate
+
+- **Stagnation** (same issues across reruns) → route to a different approach, not stop
+- **Fix-forward not converging** → after 2 iterations, BOUNCE to Flow 3 (this is routing, not giving up)
+
+The orchestrator's job is to keep things moving. When progress stalls, route to unstick. Gate's primary unstick route is BOUNCE to Build or Review.
+
+**Do NOT mark MERGE when verification has not converged.** BOUNCE with documented reason instead.
+
 ## Role Clarification: Final Verification, Not Primary Detection
 
 Flow 5 Gate is the **last line of defense**, not the first.
@@ -259,7 +292,11 @@ If the runner reports `changes_detected: true`, update build receipt + stage + s
 
 If the runner reports UNVERIFIED or scope violation, proceed with remaining Gate stations; `merge-decider` should BOUNCE to Flow 3 with the runner report as evidence.
 
-**Non-convergence guard:** The fix-forward lane runs at most twice. If `modified_files` persists after the second pass (indicating non-convergent fixes), proceed to merge-decider with the issues documented. Do not enter an infinite reseal loop chasing formatting drift.
+**Fix-forward limit:** The fix-forward lane runs at most twice. If `modified_files` persists after the second pass (indicating non-convergent fixes):
+- Document the state in `gate_fix_summary.md`
+- BOUNCE to Flow 3 to address remaining issues — this is routing, not giving up
+- Do NOT enter an infinite reseal loop chasing formatting drift
+- Do NOT mark MERGE when fix-forward has not converged
 
 ### Step 8: Traceability audit
 - `traceability-auditor` -> `.runs/<run-id>/gate/traceability_audit.md`

--- a/.claude/commands/flow-5-gate.md
+++ b/.claude/commands/flow-5-gate.md
@@ -292,10 +292,10 @@ If the runner reports `changes_detected: true`, update build receipt + stage + s
 
 If the runner reports UNVERIFIED or scope violation, proceed with remaining Gate stations; `merge-decider` should BOUNCE to Flow 3 with the runner report as evidence.
 
-**Fix-forward limit:** The fix-forward lane runs at most twice. If `modified_files` persists after the second pass (indicating non-convergent fixes):
+**Fix-forward routing:** After two passes, if `modified_files` persists (non-convergent fixes), this lane isn't converging—route out:
 - Document the state in `gate_fix_summary.md`
-- BOUNCE to Flow 3 to address remaining issues — this is routing, not giving up
-- Do NOT enter an infinite reseal loop chasing formatting drift
+- BOUNCE to Flow 3 to address remaining issues
+- The fix-forward lane stops; the flow continues via Build
 - Do NOT mark MERGE when fix-forward has not converged
 
 ### Step 8: Traceability audit

--- a/.claude/rules/00-doctrine.md
+++ b/.claude/rules/00-doctrine.md
@@ -118,6 +118,39 @@ Agents can and should debug. The goal is trust, not purity.
 
 ---
 
+## Completion Semantics
+
+"Done" is a mechanical state, not a feeling.
+
+| Status | Meaning |
+|--------|---------|
+| `VERIFIED` | Converged. Evidence panel green, evidence fresh, blockers empty. |
+| `UNVERIFIED` | Not converged, but checkpointed. Artifacts written, state captured, resumable. |
+| `CANNOT_PROCEED` | Mechanical failure. Tooling broken, permissions missing, infra down. |
+
+**UNVERIFIED is not failure. It's honest state.**
+
+### Flows Run to Completion
+
+Flows never stop mid-execution. They run to the boundary and checkpoint.
+
+- **VERIFIED** = Evidence says done (panel green, evidence fresh, blockers empty)
+- **UNVERIFIED** = External constraint hit (artifacts written, state captured, resumable)
+
+The only external constraints (all rare):
+
+| Constraint | What It Means | How Rare |
+|------------|---------------|----------|
+| **Budget** | Tokens, time, or CI minutes exhausted | Occasional |
+| **Access** | Tooling broken, permissions missing, infra down | Rare |
+| **Authority** | Business decision requiring human judgment | Very rare |
+
+**Everything else is routing.** Stagnation → route differently. Oscillation → break the cycle. Failure → route to fixer. "Blocked" is almost always just "route to the right agent."
+
+Counts are not exit criteria. "3 tries" means run it again. Stagnation triggers rerouting, not stopping.
+
+---
+
 ## The Physics
 
 These are non-negotiable invariants. Violating them breaks the system.
@@ -263,7 +296,7 @@ This approach draws from:
 
 ## The Laws Are Physics
 
-The ten laws in `docs/explanation/laws-of-the-swarm.md` are not preferences. They are the physics that makes the system work. Violating them breaks the system in predictable ways.
+The eleven laws in `docs/explanation/laws-of-the-swarm.md` are not preferences. They are the physics that makes the system work. Violating them breaks the system in predictable ways.
 
 When proposing a change, ask:
 - Does this violate any law?
@@ -274,7 +307,7 @@ When proposing a change, ask:
 
 ## See Also
 
-- [laws-of-the-swarm.md](../../docs/explanation/laws-of-the-swarm.md) — The ten immutable rules
+- [laws-of-the-swarm.md](../../docs/explanation/laws-of-the-swarm.md) — The eleven immutable rules
 - [economics.md](../../docs/explanation/economics.md) — The math that makes this work
 - [stochastic-compiler.md](../../docs/explanation/stochastic-compiler.md) — The compiler mental model
 - [why-ops-first.md](../../docs/explanation/why-ops-first.md) — Default-allow philosophy

--- a/.claude/rules/00-doctrine.md
+++ b/.claude/rules/00-doctrine.md
@@ -143,7 +143,7 @@ The only external constraints (all rare):
 |------------|---------------|----------|
 | **Budget** | Tokens, time, or CI minutes exhausted | Occasional |
 | **Access** | Tooling broken, permissions missing, infra down | Rare |
-| **Authority** | Business decision requiring human judgment | Very rare |
+| **Authority** | Non-derivable decision with no safe default | Very rare (prefer DEFAULTED + log) |
 
 **Everything else is routing.** Stagnation → route differently. Oscillation → break the cycle. Failure → route to fixer. "Blocked" is almost always just "route to the right agent."
 

--- a/.claude/rules/40-evidence-and-quality.md
+++ b/.claude/rules/40-evidence-and-quality.md
@@ -24,6 +24,55 @@ Uncertainty is fine when labeled. Certainty without evidence is the failure mode
 
 ---
 
+## Mechanical Completion
+
+"Done" is not a feeling. It is a mechanical state.
+
+| Status | Meaning |
+|--------|---------|
+| `VERIFIED` | Converged. Evidence panel green, evidence fresh, blockers empty. |
+| `UNVERIFIED` | Not converged, but checkpointed. Artifacts written, state captured, resumable. |
+| `CANNOT_PROCEED` | Mechanical failure. Tooling broken, permissions missing, infra down. |
+
+### What Evidence Shows
+
+| Condition | Status |
+|-----------|--------|
+| Evidence exists AND passes | GREEN |
+| Evidence exists AND fails | RED |
+| Evidence does not exist | UNKNOWN |
+| Evidence is stale (SHA mismatch) | UNKNOWN |
+| Agent claims done, no evidence | UNKNOWN |
+
+**UNKNOWN is not PASS.** Missing evidence is not passing evidence.
+
+### The Rule
+
+- **If evidence doesn't exist, status is UNKNOWN**
+- **If evidence is stale, status is UNKNOWN**
+- **Green checks are necessary, not sufficient** (panel beats single sensor)
+
+### Why This Matters
+
+The default failure mode in stochastic systems is "absence feels like success." An agent that doesn't find a problem may have:
+1. Found no problems (correct)
+2. Failed to look (incorrect)
+3. Looked in the wrong place (incorrect)
+
+Only captured evidence distinguishes case 1 from cases 2 and 3.
+
+### Completion Checklist
+
+Before marking work complete:
+- [ ] Evidence artifact exists on disk
+- [ ] Evidence artifact is tied to current HEAD (fresh)
+- [ ] Evidence shows explicit pass/fail, not silence
+- [ ] Panel criteria satisfied (not just one sensor)
+
+If any checkbox is unchecked, the work is UNKNOWN, not DONE.
+
+---
+
 ## Evidence Freshness
 
 Receipts are historical. Current state is NOW.

--- a/.claude/rules/50-agent-contract.md
+++ b/.claude/rules/50-agent-contract.md
@@ -170,7 +170,9 @@ When making claims:
 
 ## The Authority Line
 
-NEEDS_HUMAN is about authority, not difficulty.
+NEEDS_HUMAN is about authority, not difficulty. **It's rare by design.**
+
+**Authority** = non-derivable decision with no safe default. Prefer DEFAULTED + log unless it's unsafe.
 
 | Agent Can Handle (DEFAULTED) | Requires Human (NEEDS_HUMAN) |
 |------------------------------|------------------------------|
@@ -182,7 +184,9 @@ NEEDS_HUMAN is about authority, not difficulty.
 The test: Does the decision require someone's **authority** or just someone's **knowledge**?
 
 If it's knowledge, agents research, default safely, document reasoning, proceed.
-If it's authority, agents surface options, explain trade-offs, and wait for boundary.
+If it's authority, agents surface options, explain trade-offs, wait for boundary.
+
+**The bias is toward DEFAULTED.** Most questions have safe defaults. Research first, default if safe, escalate only when you're truly boxed in.
 
 See [authority-not-difficulty.md](../../docs/explanation/authority-not-difficulty.md) for the full explanation.
 

--- a/.claude/rules/60-flow-orchestrators.md
+++ b/.claude/rules/60-flow-orchestrators.md
@@ -133,6 +133,97 @@ Humans are asked at flow boundaries, with context, with options, with recommenda
 
 ---
 
+## Convergence Discipline
+
+**Flows run to completion. They never stop mid-execution.**
+
+A flow ends with one of two statuses:
+
+| Status | When | What It Means |
+|--------|------|---------------|
+| **VERIFIED** | Evidence says done | Panel green, evidence fresh, blockers empty |
+| **UNVERIFIED** | External constraint hit | Artifacts written, state captured, resumable |
+
+Everything else is "keep grinding."
+
+### No Early Exit
+
+Orchestrators do not accept "DONE" prose as completion. Completion requires:
+- **Evidence panel green** (all required sensors pass), OR
+- **External constraint** forces checkpoint (complete UNVERIFIED with honest state)
+
+"Feels done" is not done. "Agent said done" is not done. **Evidence says done.**
+
+### The Loop Body
+
+The microloop that produces convergence:
+
+```
+Author → Critic → Fixer → Verifier → [if not converged] → repeat
+```
+
+For each station:
+1. Run the producer (author, implementer, etc.)
+2. Run the critic (attacks the output)
+3. If critic finds issues → run fixer → run verifier
+4. Repeat until critic says "proceed"
+
+### Routing to Unstick
+
+**Counts are not conditions. Signal is.**
+
+"We've run 3 times" → run it again. A count alone justifies nothing.
+
+**Stagnation** (same failure, no new signal) → orchestrator routes to unstick. Try a different agent, change the approach, get new signal. This is normal routing, not a special mechanism.
+
+**Oscillation** (toggling between states) → orchestrator breaks the cycle. Route to a different specialist, reframe the problem, get out of the loop.
+
+The orchestrator's job is to keep things moving. When progress stalls, route to unstick. That's orchestration.
+
+| Wrong | Right |
+|-------|-------|
+| "3 tries, moving on" | "3 tries, running again" |
+| "Stagnation detected, stopping" | "Stagnation detected, routing to different agent" |
+| "Max iterations, proceeding as done" | "Still not converged, change approach" |
+| "Timeout, assuming success" | "External constraint hit, checkpointing UNVERIFIED" |
+
+### "Clean" Means Panel Clean
+
+"Clean" is defined by the evidence panel, not by any single sensor:
+
+- **Intent fidelity**: REQ/BDD/ADR satisfied (or explicit DEFAULTED/NEEDS_HUMAN logged)
+- **Verification depth**: Tests + mutation (where required)
+- **Maintainability**: Deltas acceptable / hotspots checked
+- **Boundaries**: Stage→sanitize→persist, secrets scan on staged surface
+- **Explainability**: Cockpit + pointers
+- **Freshness**: Evidence SHA matches HEAD
+
+If any of these are red/unknown AND it matters for this change, you're not clean.
+
+### Checkpoint Report
+
+When an external constraint forces UNVERIFIED completion, document:
+
+```markdown
+## Checkpoint
+
+**Constraint:** <budget | access | authority>
+**Detail:** <what specifically: tokens exhausted, tooling broken, decision needed>
+
+**Current state:**
+- <what's done>
+- <what's not done>
+
+**Evidence (if any):**
+- <artifact path>: <what it shows>
+
+**Recommended next step:** <what to do when constraint clears>
+```
+
+This makes the flow resumable. External constraints are checkpoints, not failures. The work continues when the constraint clears.
+
+---
+
 ## Local Resolution Before Bouncing
 
 **Law 7: Local Resolution First**

--- a/.claude/rules/60-flow-orchestrators.md
+++ b/.claude/rules/60-flow-orchestrators.md
@@ -133,7 +133,7 @@ Humans are asked at flow boundaries, with context, with options, with recommenda
 
 ---
 
-## Convergence Discipline
+## Completion Discipline
 
 **Flows run to completion. They never stop mid-execution.**
 
@@ -153,6 +153,8 @@ Orchestrators do not accept "DONE" prose as completion. Completion requires:
 - **External constraint** forces checkpoint (complete UNVERIFIED with honest state)
 
 "Feels done" is not done. "Agent said done" is not done. **Evidence says done.**
+
+**Any agent claiming completion without producing evidence is automatically treated as UNKNOWN and routed to the evidence producer** (test-runner, linter, mutation, etc.). This is the stop-hook that prevents early exit.
 
 ### The Loop Body
 
@@ -220,7 +222,9 @@ When an external constraint forces UNVERIFIED completion, document:
 **Recommended next step:** <what to do when constraint clears>
 ```
 
-This makes the flow resumable. External constraints are checkpoints, not failures. The work continues when the constraint clears.
+**Checkpoint means: save state, publish artifacts, recommend next route. Work continues when constraint clears.**
+
+This makes the flow resumable. External constraints are checkpoints, not failures. UNVERIFIED is not failure—it's unmerged state.
 
 ---
 

--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -132,13 +132,14 @@ If you have extra repo scripts, run them as optional checks (they must not be re
 
 | Status | Meaning |
 |--------|---------|
-| `VERIFIED` | Adequate for purpose; blockers empty |
-| `UNVERIFIED` | Gaps/concerns remain; artifacts still written |
-| `CANNOT_PROCEED` | Mechanical failure only (IO/perms/tooling) |
+| `VERIFIED` | Converged. Evidence panel green, evidence fresh, blockers empty. |
+| `UNVERIFIED` | Not converged, but checkpointed. Artifacts written, state captured, resumable. |
+| `CANNOT_PROCEED` | Mechanical failure. Tooling broken, permissions missing, infra down. |
 
 Notes:
 
-* "BLOCKED" is **not** a pack-level status. Some agents (e.g., repo-operator) have their own internal status domain.
+* "BLOCKED" is **not** a pack-level status. "Blocked" is almost always just routing.
+* UNVERIFIED is not failure—it's honest state. The flow ran to completion with a checkpoint.
 
 ---
 

--- a/docs/explanation/bounded-fix-forward.md
+++ b/docs/explanation/bounded-fix-forward.md
@@ -106,7 +106,7 @@ The audit trail shows exactly what happened. A full rerun would bury the formatt
 
 ### Non-Convergence Guard
 
-After two passes, if issues persist, this lane isn't converging—route out. Gate proceeds to merge-decider with the issues documented. The lane stops; the flow continues.
+Observation window: if the same issues persist across two reseal passes (no new signal / no net improvement), this lane isn't converging—route out. Gate proceeds to merge-decider with the issues documented. The lane stops; the flow continues.
 
 This prevents:
 - Infinite loops where formatters fight

--- a/docs/explanation/bounded-fix-forward.md
+++ b/docs/explanation/bounded-fix-forward.md
@@ -106,7 +106,7 @@ The audit trail shows exactly what happened. A full rerun would bury the formatt
 
 ### Non-Convergence Guard
 
-The fix-forward lane runs at most twice. If issues persist after two passes, Gate proceeds to merge-decider with the issues documented.
+After two passes, if issues persist, this lane isn't converging—route out. Gate proceeds to merge-decider with the issues documented. The lane stops; the flow continues.
 
 This prevents:
 - Infinite loops where formatters fight

--- a/docs/explanation/laws-of-the-swarm.md
+++ b/docs/explanation/laws-of-the-swarm.md
@@ -192,9 +192,9 @@ Flows run to completion. Counts are not exit criteria. Almost everything is rout
 
 ### Stagnation Is Evidence-Based
 
-**Stagnation is lack of new signal:** same failure signature, same evidence, no meaningful diff change.
+**Definition:** no new signal (same failure signature, same evidence, no meaningful diff change).
 
-Stagnation triggers rerouting, not stopping:
+Response: reroute, don't stop:
 - **Same failure, no new signal** → route to a different agent, change approach
 - **Oscillation** (toggling between states) → break the cycle by routing differently
 

--- a/docs/explanation/laws-of-the-swarm.md
+++ b/docs/explanation/laws-of-the-swarm.md
@@ -189,13 +189,16 @@ Flows run to completion. Counts are not exit criteria. Almost everything is rout
 
 - **Counts are never completion criteria.** "We've run 3 times" justifies nothing.
 - **Counts are never "move on" criteria.** You don't proceed because you're tired of trying.
-- **Counts can signal stagnation.** Same failure, no new information → route differently (not stop).
 
-### When Stagnation Happens
+### Stagnation Is Evidence-Based
+
+**Stagnation is lack of new signal:** same failure signature, same evidence, no meaningful diff change.
 
 Stagnation triggers rerouting, not stopping:
 - **Same failure, no new signal** → route to a different agent, change approach
 - **Oscillation** (toggling between states) → break the cycle by routing differently
+
+Counts alone don't detect stagnation. Evidence does.
 
 The orchestrator's job is to keep things moving. When progress stalls, route to unstick. That's orchestration.
 
@@ -205,7 +208,7 @@ The orchestrator's job is to keep things moving. When progress stalls, route to 
 |------------|---------------|----------|
 | **Budget** | Tokens, time, or CI minutes exhausted | Occasional |
 | **Access** | Tooling broken, permissions missing, infra down | Rare |
-| **Authority** | Business decision requiring human judgment | Very rare |
+| **Authority** | Non-derivable decision with no safe default | Very rare (prefer DEFAULTED + log) |
 
 When an external constraint hits, checkpoint UNVERIFIED and continue when the constraint clears. The flow still runs to completion—it just ends with honest state instead of green evidence.
 

--- a/docs/explanation/laws-of-the-swarm.md
+++ b/docs/explanation/laws-of-the-swarm.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-These are the ten laws. Everything else in the pack derives from or supports these. Violating them breaks the system.
+These are the eleven laws. Everything else in the pack derives from or supports these. Violating them breaks the system.
 
 **The laws are not rules to follow. They are physics to respect.**
 
@@ -179,6 +179,48 @@ Flow 7 (Wisdom) extracts learnings from completed runs. Patterns that fail repea
 
 ---
 
+### Law 11: Keep Going
+
+Flows run to completion. Counts are not exit criteria. Almost everything is routing.
+
+**Corollary:** "3 tries then move on" is a system failure. "3 tries" → run it again.
+
+### What "Keep Going" Means
+
+- **Counts are never completion criteria.** "We've run 3 times" justifies nothing.
+- **Counts are never "move on" criteria.** You don't proceed because you're tired of trying.
+- **Counts can signal stagnation.** Same failure, no new information → route differently (not stop).
+
+### When Stagnation Happens
+
+Stagnation triggers rerouting, not stopping:
+- **Same failure, no new signal** → route to a different agent, change approach
+- **Oscillation** (toggling between states) → break the cycle by routing differently
+
+The orchestrator's job is to keep things moving. When progress stalls, route to unstick. That's orchestration.
+
+### The Only External Constraints (All Rare)
+
+| Constraint | What It Means | How Rare |
+|------------|---------------|----------|
+| **Budget** | Tokens, time, or CI minutes exhausted | Occasional |
+| **Access** | Tooling broken, permissions missing, infra down | Rare |
+| **Authority** | Business decision requiring human judgment | Very rare |
+
+When an external constraint hits, checkpoint UNVERIFIED and continue when the constraint clears. The flow still runs to completion—it just ends with honest state instead of green evidence.
+
+| Wrong | Right |
+|-------|-------|
+| "3 tries, moving on" | "3 tries, running again" |
+| "Stagnation detected, stopping" | "Stagnation detected, routing to different agent" |
+| "Max iterations, proceeding as done" | "Still not converged, change approach" |
+| "Timeout, assuming success" | "External constraint hit, checkpointing UNVERIFIED" |
+
+**Violation:** "We tried 3 times, proceeding to Gate anyway."
+**Correct:** "3 tries with same failure. Routing to a different agent to unstick."
+
+---
+
 ## How to Use These Laws
 
 ### As Design Check
@@ -224,6 +266,7 @@ These are not preferences or style choices. They are the physics that makes the 
 | Law 8 (Truth Flows Downward) | Agents override exit codes, hallucinated success |
 | Law 9 (Artifacts Reduce Work) | Artifact bloat, noise drowns signal |
 | Law 10 (System Improves) | Same failures repeat indefinitely |
+| Law 11 (Keep Going) | Early exit, count-based completion, treating routing as stopping |
 
 The laws emerged from failure. They encode what breaks when ignored.
 

--- a/docs/explanation/principles/gate-at-boundaries.md
+++ b/docs/explanation/principles/gate-at-boundaries.md
@@ -130,4 +130,4 @@ Both are required. Neither alone is sufficient.
 - [publish-boundaries.md](../publish-boundaries.md) --- The three gates in detail
 - [why-ops-first.md](../why-ops-first.md) --- The philosophy behind default-allow
 - [gate-pattern.md](gate-pattern.md) --- Comprehensive gate mechanics
-- [laws-of-the-swarm.md](../laws-of-the-swarm.md) --- All ten laws
+- [laws-of-the-swarm.md](../laws-of-the-swarm.md) --- All eleven laws


### PR DESCRIPTION
## Summary

- Align flow-3-build Convergence Discipline section with flow-5-gate table format
- "Build completes with one of two statuses" matches "Gate ends with one of two statuses"
- Consistent VERIFIED/UNVERIFIED status semantics across flows
- Reinforces lane route-out semantics

## Key Distinction from "Ralph" Loop Pattern

| Aspect | Ralph Pattern | DemoSwarm |
|--------|--------------|-----------|
| Loop termination | Persistent until completion promise OR max-iterations | Continuous routing until evidence clean |
| Iteration counts | Exit criteria ("3 tries then proceed") | Not criteria (counts justify nothing) |
| Stagnation | May hit max-iterations | Route to different agent, change approach |
| External constraints | Max-iterations is internal | Budget/access/authority only—checkpoint UNVERIFIED |
| Lane limits | Convergence limit | Route-out-of-lane decision |

**The core:** Counts are not conditions. Signal is. "3 tries" → run it again. Stagnation → route differently, don't stop.

## Test plan

- [x] `pack-check.sh` passes
- [x] No old semantics ("fuse", "max iterations as exit criteria") reappeared
- [x] "UNKNOWN is not PASS" and checkpoint semantics present where expected