### PR TITLE
docs: comprehensive overhaul of README, voice/tone guidelines, and stability checks

### DIFF
--- a/.claude/rules/60-flow-orchestrators.md
+++ b/.claude/rules/60-flow-orchestrators.md
@@ -170,6 +170,17 @@ For each station:
 3. If critic finds issues → run fixer → run verifier
 4. Repeat until critic says "proceed"
 
+### Two-Pass Minimum for Stability
+
+When fixing an issue, **re-review at least once** to confirm stability. "Two passes" is a minimum observation window, not a maximum retry count.
+
+| Good | Bad |
+|------|-----|
+| Fix → re-review → stable → proceed | Fix → assume stable → proceed |
+| Critic found nothing twice → proceed | Critic found nothing once → proceed |
+
+If re-review finds the same issue, you're not stable. Route to a different approach or escalate.
+
 ### Routing to Unstick
 
 **Counts are not conditions. Signal is.**
@@ -256,3 +267,4 @@ Try local resolution first. Bounce only when truly necessary.
 - [flow-composition.md](../../docs/explanation/flow-composition.md) — How flows compose
 - [operating-model.md](../../docs/explanation/operating-model.md) — Full operating model
 - [laws-of-the-swarm.md](../../docs/explanation/laws-of-the-swarm.md) — The immutable rules
+- [90-voice-and-tone.md](90-voice-and-tone.md) — How to communicate findings

--- a/.claude/rules/90-voice-and-tone.md
+++ b/.claude/rules/90-voice-and-tone.md
@@ -1,0 +1,141 @@
+# Voice and Tone
+
+> How we communicate. Industrial clarity, human warmth.
+
+---
+
+## The Vibe
+
+**Rust Belt Industrialism, not Silicon Valley Hype.**
+
+| We Are | We Aren't |
+|--------|-----------|
+| Industrial control system | "AI coding assistant" |
+| Refinery you operate | Chatbot you talk to |
+| AgOps (infrastructure) | Copilot (assistant) |
+| Engineering that verifies | Magic that sometimes works |
+
+Cold, industrial, deterministic—but not inhuman. Clear without being clinical. Confident without being arrogant.
+
+---
+
+## Writing Principles
+
+### Direct and Honest
+
+Say what you mean. Don't hedge unnecessarily.
+
+| Good | Bad |
+|------|-----|
+| "This pattern prevents X" | "This pattern may help reduce X" |
+| "Tests failed: 3 errors in auth.py" | "There appear to be some issues" |
+| "Not measured: mutation testing skipped" | (silent gap) |
+
+### Tables Over Prose (When They Help)
+
+Tables compress information. Use them for comparisons, mappings, and structured choices.
+
+```markdown
+| What We're Not | What We Are |
+|----------------|-------------|
+| Chatbot | Refinery |
+| Hope | Evidence |
+```
+
+But don't force everything into tables. Narrative is fine when it flows naturally.
+
+### Active Voice, Clear Subjects
+
+| Good | Bad |
+|------|-----|
+| "Critics run inside build loops" | "Build loops have critics run inside them" |
+| "The gate decides merge or bounce" | "A merge/bounce decision is made by the gate" |
+
+### Explain "Why", Not Just "What"
+
+People remember reasons better than rules.
+
+| Good | Bad |
+|------|-----|
+| "We use receipts because prose claims can be wrong" | "Always write receipts" |
+| "UNVERIFIED is honest—it means 'not yet merged'" | "UNVERIFIED is a valid status" |
+
+---
+
+## The Warmth
+
+Industrial doesn't mean cold to humans. It means treating the system mechanically while treating people with respect.
+
+### Honest About Gaps
+
+"Not measured" is acceptable. Silent gaps are not.
+
+| Good | Bad |
+|------|-----|
+| "Mutation testing skipped (no budget)" | (just not mentioning it) |
+| "We're not fully there yet" | "This is the future of development" |
+
+### No Shaming
+
+Assume good faith. Explain what to do, not what someone did wrong.
+
+| Good | Bad |
+|------|-----|
+| "If you're seeing X, try Y" | "You shouldn't have done X" |
+| "This works better when..." | "Obviously you should..." |
+
+### Teach, Don't Gatekeep
+
+The repo is both factory and curriculum. Write for the next reader.
+
+| Good | Bad |
+|------|-----|
+| "Here's how to get started" | Wall of text with no entry point |
+| Examples alongside concepts | Theory without practice |
+
+---
+
+## Specific Language Choices
+
+### Completion States
+
+| Use | Not |
+|-----|-----|
+| VERIFIED | "passed", "done", "complete" (without evidence) |
+| UNVERIFIED | PARTIAL, INCOMPLETE, FAILED (when checkpointed) |
+| CANNOT_PROCEED | BLOCKED (when truly halted) |
+
+### Routing Language
+
+| Use | Not |
+|-----|-----|
+| "Route to fixer" | "BLOCKED: needs fix" |
+| "Recommend next: code-implementer" | (no recommendation) |
+
+### Evidence Language
+
+| Use | Not |
+|-----|-----|
+| "Tests pass (see test_execution.md)" | "Tests pass" (no pointer) |
+| "Coverage: 78% (see coverage_audit.md)" | "Coverage looks good" |
+| "Not measured: mutation skipped" | (silence) |
+
+---
+
+## The Posture
+
+**Trust AND Verify.** Not "trust later." Not "verify forever then trust." Both, always.
+
+**The system earns trust through evidence, not assertions.** An agent's claim does not override an exit code.
+
+**Intent starts. Evidence decides.** Intent artifacts define success. Evidence determines if we hit it.
+
+**The verification IS the product.** Code is a byproduct. A PR that's boring to approve—because the evidence is comprehensive—is the goal.
+
+---
+
+## See Also
+
+- [the-thesis.md](../../docs/explanation/the-thesis.md) — The full story
+- [economics.md](../../docs/explanation/economics.md) — Why this works economically
+- [80-developer-experience.md](80-developer-experience.md) — UX principles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Claude Code rules live in `.claude/rules/`. They encode the physics and vibe tha
 | `60-flow-orchestrators.md` | Flow commands (scoped to `.claude/commands/flow-*`) |
 | `70-docs-and-teaching.md` | Documentation (scoped to `docs/`) |
 | `80-developer-experience.md` | UX, accessibility, investing in quality |
+| `90-voice-and-tone.md` | How we communicate: industrial clarity, human warmth |
 
 Rules are the constitution Claude loads reliably. CLAUDE.md is the contract. Docs are the textbook.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ SDLC pack for Claude Code.
 
 ---
 
+## Truth Surfaces
+
+Where the real answers live:
+
+| Surface | Location | What It Proves |
+|---------|----------|----------------|
+| **Gate verdict** | `gate/merge_decision.md` | Ship or no-ship decision |
+| **Test proof** | `build/test_execution.md` | Tests actually passed (exit codes, not claims) |
+| **Critiques** | `build/*_critique.md` | What the critics found |
+| **Receipts** | `*_receipt.json` | Mechanical summaries with evidence pointers |
+| **Diff** | The PR | Final audit surface when evidence raises doubt |
+
+If something looks off, these surfaces tell you why. The receipts are the truth; the chat is just navigation.
+
+---
+
 ## Start Here
 
 ```text
@@ -29,7 +45,7 @@ If the contract is wrong, rerun Flow 1. Fixing the spec is cheaper than fixing a
 
 ## How to Review What DemoSwarm Produces
 
-**The PR description is your primary interface.** Most reviewers won't drill into `.runs/` artifacts unless something looks wrong. The swarm produces a PR Brief in the description with: what changed, review hotspots, quality events, and proof pointers. The artifacts below are drill-down evidence when you need them.
+**The PR description is your primary interface.** Most reviewers won't drill into `.runs/` artifacts unless something looks off. The swarm produces a PR Brief in the description with: what changed, review hotspots, quality events, and proof pointers. The artifacts below are drill-down evidence when you need them.
 
 If you're reviewing a run (or a PR produced by the swarm), start here:
 
@@ -37,13 +53,15 @@ If you're reviewing a run (or a PR produced by the swarm), start here:
 2. **Test proof:** `.runs/<run-id>/build/test_execution.md` — did tests actually pass
 3. **Critiques:** `.runs/<run-id>/build/code_critique.md`, `test_critique.md` — what the critics found
 4. **Receipts:** `.runs/<run-id>/*/*_receipt.json` — mechanical summaries with evidence pointers
-5. **The diff:** the PR diff is the final audit surface
+5. **The diff:** the PR diff — your final audit surface when evidence raises doubt
 
 If you're evaluating quickly, these four files tell the whole story:
 - `signal/requirements.md` — what we intended
 - `plan/adr.md` — how we decided to build it
 - `build/build_receipt.json` — what actually ran
 - `gate/merge_decision.md` — ship or bounce
+
+**What about "Not Measured"?** Good receipts are honest about gaps. If mutation testing was skipped or coverage wasn't run, the receipt says so explicitly. Silent gaps are the failure mode—explicit "not measured" is acceptable and expected.
 
 Artifacts are the handoff. Chat is transient.
 
@@ -75,7 +93,12 @@ Agents are treated like capable peers: autonomous, productive, and occasionally 
 - **Verify with executed evidence** — tests, diffs, receipts are proof; prose is navigation
 - **Catch problems early** — critics run inside build loops, not just at the end
 
-If a flow exits **PARTIAL**, that's a save point: state is on disk, next steps are documented, and rerunning the same flow resumes where it left off.
+**Completion states:**
+- **VERIFIED** — Evidence panel green, evidence fresh, blockers empty. Done.
+- **UNVERIFIED** — Checkpointed state. Artifacts written, next steps documented, resumable.
+- **CANNOT_PROCEED** — Mechanical failure (tooling broken, permissions missing).
+
+If a flow exits UNVERIFIED, that's a save point, not a failure. State is on disk, next steps are documented, and rerunning the same flow resumes where it left off. UNVERIFIED is honest—it means "not yet merged" not "something went wrong."
 
 ---
 
@@ -134,6 +157,8 @@ Traditional tooling tracks what humans decided. DemoSwarm also records what the 
 - Gates → governance (secrets, anomalies, merge criteria)
 - `.runs/` as committed state → reproducibility (resume, audit, replay)
 
+**Want a UI for runs and receipts?** See [Flow Studio](https://github.com/EffortlessMetrics/flow-studio-swarm) — the harness that gives you a visual cockpit for this pack.
+
 ---
 
 ## Operating Model
@@ -144,6 +169,12 @@ Traditional tooling tracks what humans decided. DemoSwarm also records what the 
 - **Publish is gated:** sanitize content before commit/push/post
 
 Gates constrain what leaves the workspace, not what the model can analyze.
+
+### Routing Is Prose
+
+Agents recommend next steps in plain language. Orchestrators route by reading what agents say and deciding what makes sense. No structured routing blocks to parse, no rigid state machines. Claude understands language—we use that.
+
+This means handoffs sound like: *"Implemented 3 of 5 endpoints. The remaining 2 need the User schema. Recommend routing to code-implementer with User schema as first task."* The orchestrator reads that and acts.
 
 ### Shadow Fork Topology
 
@@ -180,6 +211,8 @@ Institutional memory in plain text, committed with the artifacts.
 ## Author
 
 Created by Steven · [effortlesssteven.com/demoswarm](https://effortlesssteven.com/demoswarm/)
+
+This pack encodes the AgOps posture: trade cheap compute for expensive senior review time. The verification IS the product.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,33 @@
 # DemoSwarm
 
-SDLC pack for Claude Code.
+SDLC pack for Claude Code that produces **review-ready PRs**: code + executed evidence + critiques, surfaced as a PR cockpit in the GitHub PR description.
 
 ---
 
-## The Shift
+## Why This Exists
 
-Models now produce nearly-working code faster than humans can review it—10x to 500x human reading speed. A model can generate, test, critique, and revise a change in the time it takes a human to read the first draft.
+The job is moving up the stack. Again.
 
-This changes the economics. Generation and iteration are cheap. Human review time is expensive. The bottleneck isn't "how fast can we produce code"—it's "how fast can a human decide yes or no with confidence."
+Punchcards → Assembly → High-level languages → **Now**.
 
-Most AI coding tools optimize the wrong thing. They make generation faster, which just produces more code for humans to review. The backlog grows.
+Models now emit and revise nearly-working implementation at machine speed—10x to 500x faster than humans can review. The bottleneck isn't "can it write code." It's *trust*: can a human decide **ship / don't ship** quickly, without reading every line?
 
-DemoSwarm optimizes for what actually matters: **better PR per dev touchpoint**. Spend tokens on iteration—critics, tests, revision loops—so by the time a human sees the PR, it's already been through the wringer. Review becomes confirmation, not discovery.
+Most AI coding tools optimize the wrong thing. They make generation faster, which produces more code for humans to review. The backlog grows. The bottleneck tightens.
 
----
-
-## How It Works
-
-You dispatch a flow. The flow spawns agents. Agents do focused work and hand off. Each step is scoped to what the model handles well. State accumulates on disk. By the end, you have a Draft PR that's been through:
-
-- **Requirements** — shaped from your initial request
-- **Design** — ADR, contracts, work plan
-- **Implementation** — code written against the design
-- **Testing** — tests written from BDD scenarios
-- **Critics** — code-critic and test-critic reviewing the output
-- **Self-review** — final check before surfacing to you
-
-The iteration happens in tokens, not in your calendar. When you review, you're reviewing the output of a process, not the first draft of a prompt.
+DemoSwarm optimizes for what actually matters: **better PR per dev touchpoint**. Spend cheap iteration (critics, tests, revision loops) to buy down uncertainty, so a human touchpoint is spent on judgment, not grinding.
 
 ---
 
-## Why Orchestration
+## What DemoSwarm Does
 
-LLMs do well on small, scoped tasks. Give a model a clear, contained problem and it produces reasonable code. But larger tasks—multi-file features, end-to-end flows, anything that requires holding multiple constraints in mind—lose coherence in a single prompt.
+DemoSwarm turns Claude Code into a repeatable pipeline:
 
-The model forgets earlier constraints. It produces pieces that don't fit together. It drifts from the original intent. This isn't a model quality problem; it's a context problem. The task exceeds what fits in a single generation.
+- **Breaks larger requests into smaller, composable steps** — so the model doesn't lose coherence on multi-file changes
+- **Runs oppositional validation inside the loop** — critics and tests catch problems before you see the PR
+- **Produces a Draft PR early** to wake bots (CodeRabbit, CI), then harvests their feedback into fixes
+- **Leaves humans with a PR that's further along** than what a single prompt can produce
 
-The fix isn't better prompts or larger context windows. It's breaking the work down:
-
-1. **Scope each step** — give the model what it needs for this task, nothing more
-2. **Accumulate state** — write artifacts to disk so nothing gets lost
-3. **Run critics in the loop** — surface issues early, when fixing is cheap
-4. **Hand off clearly** — each agent says what it did and what should happen next
-
-This is how you get larger changes through without the model losing the thread.
-
----
-
-## Oppositional Validation
-
-Single-pass generation lies to please. The model produces something plausible, you accept it, problems surface later.
-
-DemoSwarm runs critics inside the build loop. `code-critic` reviews implementation. `test-critic` reviews tests. They're adversarial—their job is to find problems, not to agree.
-
-When a critic finds issues, the orchestrator routes to a fixer. The fixer addresses the issues. The critic runs again. This continues until the critic passes or the orchestrator decides to surface the remaining issues to a human.
-
-The result: problems that would have shown up in human review—or worse, in production—get caught and fixed in the loop. The PR that reaches you has already survived scrutiny.
+This is not "AI that codes for you." It's a workflow that manufactures trust.
 
 ---
 
@@ -67,9 +38,46 @@ The result: problems that would have shown up in human review—or worse, in pro
 /flow-1-signal "Add a health check endpoint" # start a run
 ```
 
-Continue with `/flow-2-plan` → `/flow-3-build` to get a Draft PR.
+Flow 1 produces requirements and BDD scenarios. Continue with `/flow-2-plan` → `/flow-3-build` to get a Draft PR.
+
+Flow 3 opens the Draft PR to wake bots. Flow 4 harvests PR feedback. Flow 5 writes the merge decision. The GitHub PR page is where you review.
 
 **[Quickstart](docs/tutorials/quickstart.md)** · [CLAUDE.md](CLAUDE.md)
+
+---
+
+## What You Review
+
+**The PR description is your primary interface.** DemoSwarm aims to make the GitHub PR page sufficient for a fast, confident decision.
+
+A good PR cockpit answers:
+
+1. **What changed** — bounded scope, intent summary
+2. **What ran** — tests, linters, scanners that actually executed
+3. **What critics found** — and what was fixed
+4. **What's not measured** — explicit gaps, not silent ones
+5. **Where to deepen verification** — hotspots for escalation if doubt exists
+
+Hotspots are **not** "where humans line-read." Hotspots are where you escalate verification (targeted tests, scans, mutation/fuzz) if the evidence isn't convincing. Critics apply the adversarial pressure; humans arbitrate based on executed evidence.
+
+---
+
+## Truth Surfaces
+
+Where the real answers live:
+
+| Surface | Location | What It Proves |
+|---------|----------|----------------|
+| **PR cockpit** | PR description | Primary review UI: scope, proof pointers, explicit unknowns |
+| **Gate verdict** | `.runs/<run-id>/gate/merge_decision.md` | Ship or bounce (with rationale) |
+| **Test proof** | `.runs/<run-id>/build/test_execution.md` | Tests actually ran (exit codes, not claims) |
+| **Critiques** | `.runs/<run-id>/build/*_critique.md` | What critics found and prioritized |
+| **Receipts** | `.runs/<run-id>/*/*_receipt.json` | Mechanical summaries + evidence pointers |
+| **Diff** | GitHub PR diff | Final audit surface when evidence raises doubt |
+
+The PR cockpit is the default. `.runs/` is drill-down evidence and resumability.
+
+**Want a UI for runs?** [Flow Studio](https://github.com/EffortlessMetrics/flow-studio-swarm) renders `.runs/` into an operator view.
 
 ---
 
@@ -85,20 +93,22 @@ Continue with `/flow-2-plan` → `/flow-3-build` to get a Draft PR.
 | **6. Deploy** | Merge to main | CI verification |
 | **7. Wisdom** | Extract learnings | feedback for next run |
 
-Each flow breaks work into focused tasks. Agents handle one thing—`code-implementer` writes code, `test-author` writes tests, `code-critic` reviews—then hand off. State accumulates on disk, so larger changes don't exceed what the model can hold in context.
+Each flow breaks work into focused tasks. Agents handle one thing—`code-implementer` writes code, `test-author` writes tests, `code-critic` reviews—then hand off with a clear recommendation.
 
 ---
 
-## What You Review
+## The Mentality Shift
 
-The PR description is your interface. The swarm produces a summary: what changed, what was tested, what to look at if something seems off.
+Most AI tools optimize for **generation speed**. DemoSwarm optimizes for **verification speed**—how quickly can a human decide yes/no with confidence?
 
-For most reviews: read the description, skim the diff, approve or comment. That's the goal—a PR that's ready enough that review is confirmation, not discovery.
+The machine iterates. Critics apply pressure. Tools produce executed evidence. Humans arbitrate based on what's proven—and escalate verification where doubt exists.
 
-If you need to debug or audit:
-- `.runs/<run-id>/` contains the working artifacts (requirements, plans, critiques)
-- Receipts summarize what each flow did
-- **[Flow Studio](https://github.com/EffortlessMetrics/flow-studio-swarm)** renders `.runs/` into a visual cockpit
+**Completion states:**
+- **VERIFIED** — Evidence is green and fresh. Blockers empty. Done.
+- **UNVERIFIED** — Checkpointed state. Artifacts written, next steps documented, resumable.
+- **CANNOT_PROCEED** — Mechanical failure (tooling broken, permissions missing).
+
+UNVERIFIED means "checkpointed"—the next step is routing, not blame.
 
 ---
 
@@ -114,9 +124,27 @@ Agents are specialists. Each does one thing well:
 | `test-critic` | Reviews tests for coverage gaps |
 | `repo-operator` | Handles git operations |
 
-They work autonomously—research, decide, implement, fix what they encounter—then hand off with a clear recommendation: *"Did X, found Y, recommend routing to Z next."*
+They work autonomously—research, decide, implement, fix what they encounter—then hand off: *"Did X, found Y, recommend routing to Z next."*
 
-If a flow can't finish (missing info, failing tests), it checkpoints. Rerun the same flow to resume where it left off.
+If a flow can't finish (missing info, failing tests), it checkpoints. Rerun the same flow to resume.
+
+---
+
+## Operating Model
+
+### Work vs. Publish
+
+- **Work is default-allow:** explore, implement, run tests, iterate freely
+- **Publish is gated:** sanitize before commit/push/post
+
+Gates constrain what leaves the workspace, not what the model can analyze.
+
+### Routing Is Prose
+
+Agents recommend next steps in plain language. Orchestrators route by reading handoffs and choosing what makes sense. No brittle routing blocks to parse.
+
+Example handoff:
+> "Implemented 3 of 5 endpoints. Remaining 2 need the User schema. Route to code-implementer with User schema first."
 
 ---
 
@@ -125,8 +153,8 @@ If a flow can't finish (missing info, failing tests), it checkpoints. Rerun the 
 | Location | What's There |
 |----------|--------------|
 | `.claude/commands/` | Flow orchestrators |
-| `.claude/agents/` | Agent prompts (specialists) |
-| `.claude/skills/` | Deterministic tools (test-runner, linter) |
+| `.claude/agents/` | Workers, critics, auditors, operators |
+| `.claude/skills/` | Deterministic helpers (test-runner, linter) |
 | `.runs/` | Run artifacts (in your repo) |
 
 ---
@@ -147,6 +175,8 @@ If a flow can't finish (missing info, failing tests), it checkpoints. Rerun the 
 ## Author
 
 Created by Steven Zimmerman (@EffortlessSteven) · [effortlesssteven.com/demoswarm](https://effortlesssteven.com/demoswarm/)
+
+This pack encodes the AgOps posture: trade cheap iteration for expensive review time. Verification is the product.
 
 ---
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,27 +2,46 @@
 
 These are synthetic but realistic examples of swarm-generated artifacts. They demonstrate the expected format and content, not actual outputs.
 
-| Example | Shows |
-|---------|-------|
-| [pr-cockpit.md](pr-cockpit.md) | PR description format (the primary review UI) |
-| [code-critique.md](code-critique.md) | Critique with CRITICAL/MAJOR/MINOR/SUGGESTION severity levels |
-| [open-questions.md](open-questions.md) | How uncertainty is tracked (DEFAULTED vs NEEDS_HUMAN) |
-| [merge-decision.md](merge-decision.md) | Gate decision memo with receipt chain audit |
+**Why these examples matter:** You learn this system by seeing the artifacts. The PR cockpit, the merge decision, the critiques—these are what review actually looks like. Read them to understand the posture.
+
+| Example | Shows | What to Notice |
+|---------|-------|----------------|
+| [pr-cockpit.md](pr-cockpit.md) | PR description format | The cockpit is your primary UI, not the diff |
+| [code-critique.md](code-critique.md) | Critique severities | CRITICAL/MAJOR/MINOR/SUGGESTION have clear semantics |
+| [open-questions.md](open-questions.md) | Uncertainty tracking | DEFAULTED = safe assumption made; NEEDS_HUMAN = requires authority |
+| [merge-decision.md](merge-decision.md) | Gate decision memo | Receipt chain audit shows how verification flows through |
+
+---
+
+## What Good Looks Like
+
+**Honest about gaps.** The PR cockpit explicitly says "Not measured: Load testing under concurrent session expiry." That's not a failure—it's honest acknowledgment. Silent gaps are the failure mode.
+
+**Evidence has pointers.** "Tests pass" isn't good enough. "142/142 passed (evidence: .runs/.../test_execution.md)" is. Claims without pointers are just prose.
+
+**Handoffs are specific.** "Done" isn't a handoff. "Implemented 3 of 5 endpoints. The remaining 2 need the User schema. Recommend routing to code-implementer with User schema as first task." is.
+
+**Completion states are mechanical.** VERIFIED means evidence panel green. UNVERIFIED means checkpointed state. Neither is a feeling.
+
+---
 
 ## Key Patterns Demonstrated
 
 All examples demonstrate these patterns:
 
-1. **Handoff structure** - "What I did / What's left / Recommendation" for routing
-2. **Evidence pointers** - File paths with line numbers (e.g., `src/auth/session.py:45-89`)
-3. **Quality scorecard** - Five surfaces: Correctness, Verification, Boundaries, Maintainability, Explanation
-4. **Stable markers** - Countable prefixes like `REQ-`, `OQ-`, `[CRITICAL]`, `[MAJOR]`, `[MINOR]`
+1. **Handoff structure** — "What I did / What's left / Recommendation" for routing
+2. **Evidence pointers** — File paths with line numbers (e.g., `src/auth/session.py:45-89`)
+3. **Quality scorecard** — Five surfaces: Correctness, Verification, Boundaries, Maintainability, Explanation
+4. **Stable markers** — Countable prefixes like `REQ-`, `OQ-`, `[CRITICAL]`, `[MAJOR]`, `[MINOR]`
+5. **"Not Measured" explicit** — Gaps are acknowledged, not hidden
+
+---
 
 ## Related Reference Docs
 
-- [pr-review-interface.md](../reference/pr-review-interface.md) - PR Brief template
-- [pr-quality-scorecard.md](../reference/pr-quality-scorecard.md) - Scorecard template and status values
-- [contracts.md](../reference/contracts.md) - Receipt schemas and handoff contracts
-- [stable-markers.md](../reference/stable-markers.md) - Marker patterns for counting
+- [pr-review-interface.md](../reference/pr-review-interface.md) — PR Brief template
+- [pr-quality-scorecard.md](../reference/pr-quality-scorecard.md) — Scorecard template and status values
+- [contracts.md](../reference/contracts.md) — Receipt schemas and handoff contracts
+- [stable-markers.md](../reference/stable-markers.md) — Marker patterns for counting
 
 These examples are intentionally small and focused. Real artifacts may be longer but follow the same structure.


### PR DESCRIPTION
## Overview
This PR represents a significant update to the DemoSwarm documentation and operational guidelines, focusing on clarifying our \"industrial\" philosophy and refining the verification-first workflow.

## Key Changes

### 1. Philosophy & Messaging (README.md)
*   **Verification over Generation:** Refocused the project's value proposition on \"verification speed\" rather than \"generation speed.\"
*   **Truth Surfaces:** Introduced the concept of \"Truth Surfaces\" to categorize where evidence resides (PR Cockpit, Gate verdicts, Test proofs, etc.).
*   **The Seven Flows:** Streamlined the description of the seven flows to emphasize their purpose and specific outputs.

### 2. Voice & Tone Rules (.claude/rules/90-voice-and-tone.md)
*   Established the \"Rust Belt Industrialism\" vibe: cold, deterministic, but honest and respectful.
*   Added specific guidelines for writing principles: \"Tables Over Prose,\" \"Active Voice,\" and \"Explain Why, Not Just What.\"
*   Standardized completion states (VERIFIED, UNVERIFIED, CANNOT_PROCEED) and evidence language.

### 3. Flow Stability (.claude/rules/60-flow-orchestrators.md)
*   **Two-Pass Minimum:** Added a mandatory re-review step for fixes to ensure stability before proceeding.
*   Refined the \"Routing to Unstick\" logic to prioritize signal over simple retry counts.

### 4. Examples & Training (docs/examples/README.md)
*   Added a \"What Good Looks Like\" section to teach the posture of being honest about gaps and providing evidence pointers.
*   Updated example tables to include \"What to Notice\" for better instructional value.

## Why This Matters
As the bottleneck of AI development shifts from \"can it code\" to \"can we trust it,\" these changes codify the processes that manufacture trust through executed evidence rather than prose assertions.