### PR TITLE
fix: align QID format with canonical codes

### DIFF
--- a/docs/examples/build-receipt.md
+++ b/docs/examples/build-receipt.md
@@ -1,0 +1,47 @@
+# Sample Build Receipt
+
+This is an example of a build receipt - the durable record of what Flow 3 (Build) produced.
+
+---
+
+# Build Receipt: feat-session-timeout
+
+**Run ID:** feat-session-timeout
+**Flow:** Build (Flow 3)
+**Completed:** 2024-01-15T14:32:00Z
+
+## What Was Built
+
+- SessionManager class with configurable timeout
+- Integration with existing auth middleware
+- 8 new test cases covering timeout scenarios
+
+## Verification Summary
+
+| Check | Result |
+|-------|--------|
+| Tests | 142 passed, 0 failed |
+| Coverage | 94% on new code |
+| Lint | Clean |
+| Type check | Clean |
+| Mutation | Not run |
+
+## Critiques Applied
+
+- code-critique: 2 MINOR findings (acknowledged, not blocking)
+- test-critique: Clean
+
+## Files Changed
+
+- `src/auth/session_manager.py` (new)
+- `src/auth/middleware.py` (modified)
+- `src/config/defaults.py` (modified)
+- `tests/auth/test_session_timeout.py` (new)
+
+## Open Questions
+
+None.
+
+## Handoff
+
+Ready for Gate (Flow 5). All verification passed. Minor critique findings documented but non-blocking.

--- a/tools/demoswarm-pack-check/tests/check_integration_test.rs
+++ b/tools/demoswarm-pack-check/tests/check_integration_test.rs
@@ -347,9 +347,14 @@ mod openq_prefix_validation {
     fn test_valid_openq_fixture_has_canonical_codes() {
         let content = read_fixture("open_questions_valid.md");
 
-        // Should contain canonical flow codes
+        // Should contain canonical flow codes (full words, per contracts.rs)
         let canonical_codes = [
-            "OQ-SIG-", "OQ-PLN-", "OQ-BLD-", "OQ-GAT-", "OQ-DEP-", "OQ-WIS-",
+            "OQ-SIG-",    // Signal uses SIG (abbreviation)
+            "OQ-PLAN-",   // Plan uses PLAN (full word)
+            "OQ-BUILD-",  // Build uses BUILD (full word)
+            "OQ-GATE-",   // Gate uses GATE (full word)
+            "OQ-DEPLOY-", // Deploy uses DEPLOY (full word)
+            "OQ-WISDOM-", // Wisdom uses WISDOM (full word)
         ];
         for code in canonical_codes {
             assert!(
@@ -359,14 +364,14 @@ mod openq_prefix_validation {
             );
         }
 
-        // Should NOT contain non-canonical codes
+        // Should NOT contain non-canonical abbreviated codes
         assert!(
-            !content.contains("OQ-PLAN-"),
-            "Should not have PLAN (use PLN)"
+            !content.contains("OQ-PLN-"),
+            "Should not have PLN (use PLAN)"
         );
         assert!(
-            !content.contains("OQ-BUILD-"),
-            "Should not have BUILD (use BLD)"
+            !content.contains("OQ-BLD-"),
+            "Should not have BLD (use BUILD)"
         );
     }
 
@@ -375,26 +380,26 @@ mod openq_prefix_validation {
     fn test_invalid_openq_fixture_has_non_canonical_codes() {
         let content = read_fixture("open_questions_invalid.md");
 
-        // Should contain non-canonical codes
+        // Should contain non-canonical abbreviated codes
         assert!(
-            content.contains("OQ-PLAN-"),
-            "Invalid fixture should have PLAN"
+            content.contains("OQ-PLN-"),
+            "Invalid fixture should have PLN (abbreviated)"
         );
         assert!(
-            content.contains("OQ-BUILD-"),
-            "Invalid fixture should have BUILD"
+            content.contains("OQ-BLD-"),
+            "Invalid fixture should have BLD (abbreviated)"
         );
         assert!(
-            content.contains("OQ-GATE-"),
-            "Invalid fixture should have GATE"
+            content.contains("OQ-GAT-"),
+            "Invalid fixture should have GAT (abbreviated)"
         );
         assert!(
-            content.contains("OQ-DEPLOY-"),
-            "Invalid fixture should have DEPLOY"
+            content.contains("OQ-DEP-"),
+            "Invalid fixture should have DEP (abbreviated)"
         );
         assert!(
-            content.contains("OQ-WISDOM-"),
-            "Invalid fixture should have WISDOM"
+            content.contains("OQ-WIS-"),
+            "Invalid fixture should have WIS (abbreviated)"
         );
     }
 
@@ -403,7 +408,7 @@ mod openq_prefix_validation {
     fn test_bad_padding_fixture_has_invalid_suffixes() {
         let content = read_fixture("open_questions_bad_padding.md");
 
-        // Should contain invalid padding patterns
+        // Should contain invalid padding patterns (using canonical flow codes)
         assert!(
             content.contains("OQ-SIG-1\n")
                 || content.contains("OQ-SIG-1 ")
@@ -411,11 +416,11 @@ mod openq_prefix_validation {
             "Should have single-digit suffix"
         );
         assert!(
-            content.contains("OQ-PLN-12") || content.contains("OQ-PLN-12"),
+            content.contains("OQ-PLAN-12"),
             "Should have two-digit suffix"
         );
         assert!(
-            content.contains("OQ-BLD-1234"),
+            content.contains("OQ-BUILD-1234"),
             "Should have four-digit suffix"
         );
     }
@@ -425,28 +430,28 @@ mod openq_prefix_validation {
     fn test_mixed_openq_fixture_structure() {
         let content = read_fixture("open_questions_mixed.md");
 
-        // Valid QIDs
+        // Valid QIDs (using canonical flow codes with proper padding)
         assert!(
             content.contains("OQ-SIG-001"),
             "Should have valid OQ-SIG-001"
         );
         assert!(
-            content.contains("OQ-BLD-003"),
-            "Should have valid OQ-BLD-003"
+            content.contains("OQ-PLAN-002"),
+            "Should have valid OQ-PLAN-002"
         );
         assert!(
-            content.contains("OQ-GAT-999"),
-            "Should have valid OQ-GAT-999"
+            content.contains("OQ-GATE-999"),
+            "Should have valid OQ-GATE-999"
         );
 
         // Invalid QIDs
         assert!(
-            content.contains("OQ-PLAN-002"),
-            "Should have invalid PLAN code"
+            content.contains("OQ-BLD-003"),
+            "Should have invalid BLD code (abbreviated, non-canonical)"
         );
         assert!(
-            content.contains("OQ-BLD-3\n") || content.contains("- QID: OQ-BLD-3"),
-            "Should have invalid padding OQ-BLD-3"
+            content.contains("OQ-BUILD-3\n") || content.contains("- QID: OQ-BUILD-3"),
+            "Should have invalid padding OQ-BUILD-3"
         );
     }
 
@@ -456,25 +461,25 @@ mod openq_prefix_validation {
     // Behavior:
     // 1. Scans .runs/**/open_questions.md files
     // 2. Extracts QID patterns matching OQ-<CODE>-<NNN>
-    // 3. Validates <CODE> is one of: SIG, PLN, BLD, GAT, DEP, WIS
+    // 3. Validates <CODE> is one of: SIG, PLAN, BUILD, REVIEW, GATE, DEPLOY, WISDOM
     // 4. Validates <NNN> is exactly 3 digits (zero-padded)
     // ==========================================================================
 
     /// REQ-003: Check 53 detects non-canonical flow codes.
-    /// Verifies that QIDs with non-canonical flow codes (PLAN instead of PLN) are flagged.
+    /// Verifies that QIDs with non-canonical flow codes (PLN instead of PLAN) are flagged.
     #[test]
     fn test_check_53_detects_non_canonical_flow_code() {
-        // Verify the invalid fixture contains non-canonical codes
+        // Verify the invalid fixture contains non-canonical (abbreviated) codes
         let invalid_content = read_fixture("open_questions_invalid.md");
 
-        // Should contain non-canonical codes like PLAN, BUILD, etc.
+        // Should contain non-canonical abbreviated codes like PLN, BLD, etc.
         assert!(
-            invalid_content.contains("OQ-PLAN-"),
-            "Invalid fixture should have PLAN"
+            invalid_content.contains("OQ-PLN-"),
+            "Invalid fixture should have PLN (abbreviated)"
         );
         assert!(
-            invalid_content.contains("OQ-BUILD-"),
-            "Invalid fixture should have BUILD"
+            invalid_content.contains("OQ-BLD-"),
+            "Invalid fixture should have BLD (abbreviated)"
         );
 
         // Run pack-check on actual repo and verify check 53 runs
@@ -506,11 +511,11 @@ mod openq_prefix_validation {
         // Verify the bad padding fixture has invalid suffixes
         let bad_padding_content = read_fixture("open_questions_bad_padding.md");
 
-        // Should have examples of bad padding
+        // Should have examples of bad padding (using canonical flow codes)
         assert!(
             bad_padding_content.contains("OQ-SIG-1")
-                || bad_padding_content.contains("OQ-PLN-12")
-                || bad_padding_content.contains("OQ-BLD-1234"),
+                || bad_padding_content.contains("OQ-PLAN-12")
+                || bad_padding_content.contains("OQ-BUILD-1234"),
             "Bad padding fixture should have non-3-digit suffixes"
         );
 
@@ -546,9 +551,14 @@ mod openq_prefix_validation {
         // Verify the valid fixture has correct QID format
         let valid_content = read_fixture("open_questions_valid.md");
 
-        // Should contain canonical flow codes
+        // Should contain canonical flow codes (full words, per contracts.rs)
         let canonical_codes = [
-            "OQ-SIG-", "OQ-PLN-", "OQ-BLD-", "OQ-GAT-", "OQ-DEP-", "OQ-WIS-",
+            "OQ-SIG-",    // Signal uses SIG (abbreviation)
+            "OQ-PLAN-",   // Plan uses PLAN (full word)
+            "OQ-BUILD-",  // Build uses BUILD (full word)
+            "OQ-GATE-",   // Gate uses GATE (full word)
+            "OQ-DEPLOY-", // Deploy uses DEPLOY (full word)
+            "OQ-WISDOM-", // Wisdom uses WISDOM (full word)
         ];
         for code in canonical_codes {
             assert!(
@@ -558,14 +568,14 @@ mod openq_prefix_validation {
             );
         }
 
-        // Should NOT contain non-canonical codes
+        // Should NOT contain non-canonical abbreviated codes
         assert!(
-            !valid_content.contains("OQ-PLAN-"),
-            "Valid fixture should NOT have PLAN"
+            !valid_content.contains("OQ-PLN-"),
+            "Valid fixture should NOT have PLN (use PLAN)"
         );
         assert!(
-            !valid_content.contains("OQ-BUILD-"),
-            "Valid fixture should NOT have BUILD"
+            !valid_content.contains("OQ-BLD-"),
+            "Valid fixture should NOT have BLD (use BUILD)"
         );
 
         // Run pack-check on actual repo

--- a/tools/demoswarm-pack-check/tests/fixtures/open_questions_bad_padding.md
+++ b/tools/demoswarm-pack-check/tests/fixtures/open_questions_bad_padding.md
@@ -8,13 +8,13 @@ This is a test fixture with invalid numeric suffix padding.
   - Q: Single digit suffix? [OPEN]
   - A: Should be OQ-SIG-001
 
-- QID: OQ-PLN-12
+- QID: OQ-PLAN-12
   - Q: Two digit suffix? [OPEN]
-  - A: Should be OQ-PLN-012
+  - A: Should be OQ-PLAN-012
 
-- QID: OQ-BLD-1234
+- QID: OQ-BUILD-1234
   - Q: Four digit suffix? [OPEN]
-  - A: Should be OQ-BLD-999 max (3 digits)
+  - A: Should be OQ-BUILD-999 max (3 digits)
 
 ## Notes
 

--- a/tools/demoswarm-pack-check/tests/fixtures/open_questions_mixed.md
+++ b/tools/demoswarm-pack-check/tests/fixtures/open_questions_mixed.md
@@ -9,24 +9,24 @@ This is a test fixture with a mix of valid and invalid QID patterns.
   - A: This uses canonical SIG code
 
 - QID: OQ-PLAN-002
-  - Q: Invalid flow code (PLAN should be PLN) [OPEN]
-  - A: This is a violation
+  - Q: Valid question with canonical PLAN code [OPEN]
+  - A: This is correct (PLAN is canonical)
 
 - QID: OQ-BLD-003
-  - Q: Valid question with canonical BLD code [OPEN]
-  - A: This is correct
+  - Q: Invalid flow code (BLD should be BUILD) [OPEN]
+  - A: This is a violation
 
-- QID: OQ-BLD-3
+- QID: OQ-BUILD-3
   - Q: Invalid padding (should be 003) [OPEN]
   - A: This is a violation
 
-- QID: OQ-GAT-999
+- QID: OQ-GATE-999
   - Q: Valid at upper bound [OPEN]
-  - A: This uses canonical GAT code
+  - A: This uses canonical GATE code
 
 ## Notes
 
 This file tests multi-match validation:
 
-- 3 valid QIDs: OQ-SIG-001, OQ-BLD-003, OQ-GAT-999
-- 2 invalid QIDs: OQ-PLAN-002 (non-canonical PLAN), OQ-BLD-3 (bad padding)
+- 3 valid QIDs: OQ-SIG-001, OQ-PLAN-002, OQ-GATE-999
+- 2 invalid QIDs: OQ-BLD-003 (non-canonical BLD), OQ-BUILD-3 (bad padding)

--- a/tools/demoswarm-pack-check/tests/fixtures/open_questions_valid.md
+++ b/tools/demoswarm-pack-check/tests/fixtures/open_questions_valid.md
@@ -8,23 +8,27 @@ This is a test fixture with valid QID patterns.
   - Q: What is the expected behavior for edge case inputs? [OPEN]
   - A: Pending stakeholder confirmation
 
-- QID: OQ-PLN-002
+- QID: OQ-PLAN-002
   - Q: Should the API contract include retry semantics? [RESOLVED]
   - A: Yes, include exponential backoff per ADR-001
 
-- QID: OQ-BLD-003
+- QID: OQ-BUILD-003
   - Q: Which test framework to use? [RESOLVED]
   - A: Use existing project conventions
 
-- QID: OQ-GAT-004
+- QID: OQ-REVIEW-004
+  - Q: What review criteria apply? [OPEN]
+  - A: Pending
+
+- QID: OQ-GATE-005
   - Q: What merge verdict criteria apply? [OPEN]
   - A: Pending
 
-- QID: OQ-DEP-005
+- QID: OQ-DEPLOY-006
   - Q: Is canary deployment required? [RESOLVED]
   - A: Not for this change
 
-- QID: OQ-WIS-006
+- QID: OQ-WISDOM-007
   - Q: What learnings should be captured? [OPEN]
   - A: Pending flow completion
 
@@ -33,10 +37,11 @@ This is a test fixture with valid QID patterns.
 All QIDs above use canonical 3-letter flow codes:
 
 - SIG (Signal)
-- PLN (Plan)
-- BLD (Build)
-- GAT (Gate)
-- DEP (Deploy)
-- WIS (Wisdom)
+- PLAN (Plan)
+- BUILD (Build)
+- REVIEW (Review)
+- GATE (Gate)
+- DEPLOY (Deploy)
+- WISDOM (Wisdom)
 
 All numeric suffixes are zero-padded to 3 digits.


### PR DESCRIPTION
## Summary

Production CI was failing because test fixtures used 3-letter codes (PLN, BLD, GAT) while `contracts.rs` defines canonical codes as full words (PLAN, BUILD, GATE, etc.).

This syncs fixes from demo-swarm (production) that were overwritten during the last downstream merge.

## Changes

- Update test fixtures to use canonical QID format (SIG, PLAN, BUILD, REVIEW, GATE, DEPLOY, WISDOM)
- Update integration tests to expect canonical codes  
- Add `build-receipt.md` example from production

## Verification

- All 41 Rust tests pass locally
- Pack-check passes

## Test plan

- [ ] CI passes (pack-check-tests)
- [ ] Merge to main
- [ ] Sync back to demo-swarm