### PR TITLE
chore: normalize line endings for Rust files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.json text eol=lf
+*.rs text eol=lf
+*.toml text eol=lf


### PR DESCRIPTION
## Summary

Add `*.rs` and `*.toml` to `.gitattributes` to enforce LF line endings.

This prevents CRLF/LF drift between Windows and Unix environments, which was causing large spurious diffs when comparing branches.

## Test plan

- [ ] CI passes