### PR TITLE
chore: align gh-reporter heading with production

### DIFF
--- a/.claude/agents/gh-reporter.md
+++ b/.claude/agents/gh-reporter.md
@@ -445,7 +445,7 @@ comment_id: <id or null>
 **Recommendation:** <specific next step with reasoning>
 ```
 
-## Handoff
+## Handoff Guidelines
 
 After writing outputs, provide a natural language handoff to the orchestrator.
 


### PR DESCRIPTION
Aligns ## Handoff → ## Handoff Guidelines to match production.