### PR TITLE
spec: define repo-native spec namespace

### DIFF
--- a/.demoswarm-spec/README.md
+++ b/.demoswarm-spec/README.md
@@ -1,0 +1,25 @@
+# DemoSwarm Spec Rails (`.demoswarm-spec`)
+
+This directory is the **durable, repo-owned source-of-truth control plane** for DemoSwarm specification work.
+
+It owns long-term artifacts such as:
+
+- proposals (why)
+- specs (what)
+- ADRs (decision)
+- lane trackers and implementation plans (how)
+- support claim mapping and policy references (what users may believe / what is enforced)
+- closeouts (what happened)
+
+## Scope and ownership
+
+The `.demoswarm-spec/` namespace is owned by this repository and is tool-neutral.
+
+External and agent-specific directories are awareness-only for this lane and are **not** owned by this system:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+Those locations may exist and may read from this namespace, but durable rails live here.

--- a/.demoswarm-spec/index.toml
+++ b/.demoswarm-spec/index.toml
@@ -1,0 +1,16 @@
+schema_version = "1.0"
+
+repo = "demoswarm"
+namespace = ".demoswarm-spec"
+
+[conventions]
+proposal_prefix = "DS-PROP"
+spec_prefix = "DS-SPEC"
+adr_prefix = "DS-ADR"
+lane_prefix = "DS-LANE"
+
+[external_namespaces]
+codex = ".codex"
+speckit = ".spec"
+claude = ".claude"
+jules = ".jules"

--- a/docs/contributing/spec-rails.md
+++ b/docs/contributing/spec-rails.md
@@ -1,0 +1,25 @@
+# Contributing to DemoSwarm Spec Rails
+
+When adding or updating durable planning and specification artifacts:
+
+1. Place durable artifacts under `.demoswarm-spec/`.
+2. Keep each artifact type focused:
+   - proposal = why and alternatives
+   - spec = behavioral contract and proof obligations
+   - ADR = durable architecture decision
+   - lane tracker = execution state and work-item progression
+   - implementation plan = PR-sized sequence
+   - closeout = what landed, proof, and remaining work
+3. Link artifacts through `.demoswarm-spec/index.toml`.
+4. Do not put durable rails inside agent or tool state directories.
+
+## Non-owned directories for this lane
+
+The following directories are awareness-only and not managed by this system:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+If these directories are present, leave them untouched unless a separate lane explicitly governs them.

--- a/docs/spec-style.md
+++ b/docs/spec-style.md
@@ -1,0 +1,41 @@
+# Spec Style and Source-of-Truth Rails
+
+DemoSwarm keeps a full source-of-truth chain:
+
+- roadmap
+- proposal / PRD
+- spec
+- ADR (when needed)
+- lane tracker + implementation plan
+- PRs and issues
+- proof commands and receipts
+- support-tier or policy updates
+- closeout
+
+## Durable location
+
+The durable repo-native knowledge base lives in:
+
+- `.demoswarm-spec/`
+
+This is the long-term source of truth for spec artifacts.
+
+## Human-facing explanation
+
+Human-readable contributor guidance belongs in `docs/`.
+
+In particular:
+
+- this file explains the method
+- `docs/contributing/spec-rails.md` explains contribution workflow
+
+## External tool state
+
+Tool-specific folders are **not** durable rails for this system:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+They may coexist, but this spec lane does not own, migrate, or depend on their internal state.


### PR DESCRIPTION
### Motivation

- Keep durable proposal/spec/ADR/implementation-tracker/closeout rails in a repo-owned namespace rather than in agent/tool-specific directories so long-term artifacts are tool-neutral and auditable. 
- Provide clear contributor guidance and conventions so artifacts are discoverable and agents may read but not own or mutate durable state.

### Description

- Add `.demoswarm-spec/README.md` to document the durable repo spec rails and explicitly mark `.codex`, `.spec`, `.claude`, and `.jules` as awareness-only. 
- Add `.demoswarm-spec/index.toml` containing `schema_version`, `repo`, `namespace`, artifact naming conventions, and `external_namespaces` entries. 
- Add `docs/spec-style.md` to explain the source-of-truth chain and add `docs/contributing/spec-rails.md` with contributor rules for where to place proposals, specs, ADRs, lane trackers, implementation plans, support maps, and closeouts. 

### Testing

- Ran `git diff --check` to validate the patch for whitespace and basic issues, and the check completed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebe297f4483338cbc24a66653d54f)