### PR TITLE
rails: add .rails framework footprint, templates, and initial artifacts

### DIFF
--- a/.rails/README.md
+++ b/.rails/README.md
@@ -1,0 +1,37 @@
+# Rails
+
+Rails is this repo's durable source-of-truth framework.
+
+It separates:
+
+- proposals: why work exists
+- specs: what behavior must be true
+- ADRs: durable architecture decisions
+- lanes: focused implementation trackers
+- support maps: what users may believe and what proves it
+- policy references: governed ledgers and enforcement sources
+- closeouts: what landed, what proved it, and what remains
+
+## Scope
+
+Rails owns `.rails/` and the human-facing docs that explain it.
+
+Rails does not own, modify, migrate, or validate:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+Those may overlap conceptually, but they are external tool or agent spaces.
+
+## Source-of-truth rule
+
+Proposal says why.
+Spec says what.
+ADR says what decision.
+Lane says what sequence.
+Support says what users may believe.
+Policy says what exceptions exist.
+Receipts say what proved it.
+Closeout says what happened.

--- a/.rails/adr/DSWARM-ADR-0001-rails-framework-footprint.md
+++ b/.rails/adr/DSWARM-ADR-0001-rails-framework-footprint.md
@@ -1,0 +1,27 @@
+# DSWARM-ADR-0001: Rails framework footprint
+
+Status: accepted
+Date: 2026-05-21
+Owner: docs-and-governance
+Linked proposal: DSWARM-PROP-0001
+Linked specs: DSWARM-SPEC-0001
+
+## Decision
+
+Long-term proposal/spec/ADR/lane/closeout artifacts live in `.rails/`. Agent/tool-specific state remains external.
+
+## Context
+
+The repository needs a portable footprint that survives tool changes and supports validators, portal surfaces, and future command-palette interfaces.
+
+## Consequences
+
+Durable artifacts gain stable ownership and indexability, while external namespaces stay awareness-only.
+
+## Alternatives considered
+
+Repo-scoped hidden directories and agent-owned spaces were rejected because they couple long-lived truth to tool execution state.
+
+## Follow-up specs / plans
+
+Implement indexed artifact graph constraints and lane tracker validation.

--- a/.rails/index.toml
+++ b/.rails/index.toml
@@ -1,0 +1,48 @@
+schema_version = "1.0"
+
+[project]
+repo = "demo-swarm-swarm"
+framework = "rails"
+root = ".rails"
+
+[conventions]
+proposal_prefix = "DSWARM-PROP"
+spec_prefix = "DSWARM-SPEC"
+adr_prefix = "DSWARM-ADR"
+lane_prefix = "DSWARM-LANE"
+
+[external_namespaces]
+codex = ".codex"
+speckit = ".spec"
+claude = ".claude"
+jules = ".jules"
+
+[[artifact]]
+id = "DSWARM-PROP-0001"
+kind = "proposal"
+path = ".rails/proposals/DSWARM-PROP-0001-rails-knowledge-base.md"
+status = "accepted"
+owner = "rails-adoption"
+
+[[artifact]]
+id = "DSWARM-SPEC-0001"
+kind = "spec"
+path = ".rails/specs/DSWARM-SPEC-0001-rails-artifact-graph.md"
+status = "accepted"
+owner = "rails-adoption"
+linked_proposal = "DSWARM-PROP-0001"
+
+[[artifact]]
+id = "DSWARM-ADR-0001"
+kind = "adr"
+path = ".rails/adr/DSWARM-ADR-0001-rails-framework-footprint.md"
+status = "accepted"
+owner = "rails-adoption"
+linked_specs = ["DSWARM-SPEC-0001"]
+
+[[lane]]
+id = "rails-adoption"
+name = "Rails adoption"
+path = ".rails/lanes/rails-adoption/tracker.toml"
+status = "active"
+owner = "docs-and-governance"

--- a/.rails/lanes/rails-adoption/implementation-plan.md
+++ b/.rails/lanes/rails-adoption/implementation-plan.md
@@ -1,0 +1,21 @@
+# Implementation plan: rails-adoption
+
+## Objective
+
+Adopt `.rails/` as the durable repository knowledge base and establish indexed first artifacts.
+
+## PR sequence
+
+1. Add framework footprint and human-facing docs.
+2. Add templates for proposals/specs/ADRs/lanes/closeouts and support/policy references.
+3. Add initial proposal, ADR, spec, and lane tracker artifacts.
+
+## Dependencies
+
+- Maintainer agreement on external namespace boundaries.
+- Follow-up validator work for index and lane semantics.
+
+## Proof strategy
+
+- `git diff --check`
+- Index and artifact link review via `.rails/index.toml`

--- a/.rails/lanes/rails-adoption/tracker.toml
+++ b/.rails/lanes/rails-adoption/tracker.toml
@@ -1,0 +1,29 @@
+schema_version = "1.0"
+
+id = "rails-adoption"
+name = "Rails adoption"
+status = "active"
+owner = "docs-and-governance"
+
+objective = """
+Adopt the durable `.rails/` framework footprint with indexed artifacts and focused sequencing.
+"""
+
+end_state = [
+  "Framework footprint exists under .rails/.",
+  "Initial proposal/spec/ADR are indexed and linked.",
+  "Human-facing docs describe ownership boundaries.",
+]
+
+[[work_item]]
+id = "rails-adoption-bootstrap"
+status = "ready"
+proposal = "DSWARM-PROP-0001"
+spec = "DSWARM-SPEC-0001"
+adr = "DSWARM-ADR-0001"
+implementation_plan = ".rails/lanes/rails-adoption/implementation-plan.md"
+blocks = []
+blocked_by = []
+proof = [
+  "git diff --check",
+]

--- a/.rails/proposals/DSWARM-PROP-0001-rails-knowledge-base.md
+++ b/.rails/proposals/DSWARM-PROP-0001-rails-knowledge-base.md
@@ -1,0 +1,59 @@
+# DSWARM-PROP-0001: Rails knowledge base
+
+Status: accepted
+Owner: docs-and-governance
+Created: 2026-05-21
+Target milestone: vNext
+Linked specs: DSWARM-SPEC-0001
+Linked ADRs: DSWARM-ADR-0001
+Linked lanes: rails-adoption
+
+## Problem
+
+The repository lacks a durable, tool-agnostic source-of-truth structure for long-lived product and implementation artifacts.
+
+## Users and surfaces
+
+Maintainers, contributors, and downstream tooling that needs stable access to proposal/spec/ADR/lane/closeout artifacts.
+
+## Success criteria
+
+A portable `.rails/` footprint exists with indexed artifacts and lane-focused sequencing.
+
+## Proposed shape
+
+Adopt `.rails/` as the durable framework directory and keep agent/tool namespaces awareness-only.
+
+## Alternatives considered
+
+Keep artifacts in agent-owned directories (`.codex/`, `.spec/`) or use repo-specific hidden directories. Rejected for portability and ownership ambiguity.
+
+## Specs to create or update
+
+- DSWARM-SPEC-0001
+
+## Architecture decisions needed
+
+- DSWARM-ADR-0001
+
+## Implementation campaign shape
+
+1. Add framework footprint and docs.
+2. Add templates and initial indexed artifacts.
+3. Add validators and closeout flows.
+
+## Evidence plan
+
+`git diff --check` for formatting and repository review via tracked artifacts in `.rails/index.toml`.
+
+## Risks
+
+Drift between indexed artifacts and filesystem paths without validation tooling.
+
+## Non-goals
+
+Migrating or modifying external namespaces such as `.codex/` and `.spec/`.
+
+## Exit criteria
+
+`.rails/` is established, documented, and linked with at least one proposal/spec/ADR and one active lane.

--- a/.rails/specs/DSWARM-SPEC-0001-rails-artifact-graph.md
+++ b/.rails/specs/DSWARM-SPEC-0001-rails-artifact-graph.md
@@ -1,0 +1,56 @@
+# DSWARM-SPEC-0001: Rails artifact graph contract
+
+Status: accepted
+Owner: docs-and-governance
+Created: 2026-05-21
+Linked proposal: DSWARM-PROP-0001
+Linked ADRs: DSWARM-ADR-0001
+Linked lane: rails-adoption
+Linked issues:
+Linked PRs:
+Support-tier impact: none
+Policy impact: references only
+
+## Problem
+
+Without a contract, Rails artifacts can drift in location, ownership, and linkage.
+
+## Behavior
+
+- Rails artifacts must be indexed through `.rails/index.toml`.
+- Owned artifact paths must live under `.rails/`.
+- External namespaces may be listed but not owned.
+- Specs define behavior, not PR order.
+- Lane trackers define focused implementation sequencing.
+
+## Non-goals
+
+Defining external tool behavior for `.codex/`, `.spec/`, `.claude/`, or `.jules/`.
+
+## Required evidence
+
+Repository paths and index entries align, and no owned artifact path points into external namespaces.
+
+## Acceptance examples
+
+An indexed proposal/spec/ADR/lane set with valid paths and links under `.rails/`.
+
+## Test mapping
+
+Initial proof command: `git diff --check`.
+
+## Implementation mapping
+
+`.rails/index.toml`, `.rails/lanes/*/tracker.toml`, and artifact markdown files.
+
+## CI proof
+
+Current manual proof command with future validator command in xtask.
+
+## Metrics / promotion rule
+
+Promote when automated validator enforces uniqueness, path ownership, and link resolution.
+
+## Failure modes
+
+Missing files, duplicate IDs, or owned artifact paths under external namespaces must fail validation.

--- a/.rails/templates/adr.md
+++ b/.rails/templates/adr.md
@@ -1,0 +1,27 @@
+# <REPO>-ADR-0001: <Title>
+
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+
+## Decision
+
+State the durable architecture decision.
+
+## Context
+
+Why this decision exists.
+
+## Consequences
+
+What this enables and constrains.
+
+## Alternatives considered
+
+What did we reject?
+
+## Follow-up specs / plans
+
+What must be implemented?

--- a/.rails/templates/closeout.md
+++ b/.rails/templates/closeout.md
@@ -1,0 +1,26 @@
+# Closeout: <lane-id> / <date>
+
+Status:
+Owner:
+Lane:
+Related proposal:
+Related specs:
+Related ADRs:
+
+## What landed
+
+Summary of delivered behavior.
+
+## Proof
+
+- command:
+- output artifact:
+- receipt:
+
+## Follow-ups
+
+Remaining work and handoffs.
+
+## Risks and regressions
+
+What still needs watching.

--- a/.rails/templates/implementation-plan.md
+++ b/.rails/templates/implementation-plan.md
@@ -1,0 +1,23 @@
+# Implementation plan: <lane-id>
+
+## Objective
+
+What this implementation sequence is trying to make true.
+
+## PR sequence
+
+1. PR slice 1
+2. PR slice 2
+3. PR slice 3
+
+## Dependencies
+
+- Blocking artifact IDs
+- Blocking infrastructure or policy conditions
+
+## Proof strategy
+
+- Commands
+- Fixtures
+- Receipts
+- CI jobs

--- a/.rails/templates/lane-tracker.toml
+++ b/.rails/templates/lane-tracker.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+
+id = "<lane-id>"
+name = "<Lane name>"
+status = "active"
+owner = "<owner>"
+
+objective = """
+What this lane is trying to make true.
+"""
+
+end_state = [
+  "Concrete done-state item.",
+  "Another done-state item.",
+]
+
+[[work_item]]
+id = "<work-item-id>"
+status = "ready"
+proposal = "<REPO>-PROP-0001"
+spec = "<REPO>-SPEC-0001"
+adr = ""
+implementation_plan = ".rails/lanes/<lane-id>/implementation-plan.md"
+blocks = []
+blocked_by = []
+proof = [
+  "git diff --check",
+]

--- a/.rails/templates/policy-reference.toml
+++ b/.rails/templates/policy-reference.toml
@@ -1,0 +1,8 @@
+schema_version = "1.0"
+
+id = "<policy-reference-id>"
+name = "<Policy reference name>"
+owner = "<owner>"
+source = "<path-to-live-policy-ledger>"
+summary = "Reference to live enforcement policy without duplication."
+review_cadence = "monthly"

--- a/.rails/templates/proposal.md
+++ b/.rails/templates/proposal.md
@@ -1,0 +1,58 @@
+# <REPO>-PROP-0001: <Title>
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked lanes:
+
+## Problem
+
+What user pain, repo risk, or product gap exists?
+
+## Users and surfaces
+
+Who benefits?
+Which commands, APIs, crates, docs, CI lanes, policies, or support tiers are affected?
+
+## Success criteria
+
+What must be true when complete?
+
+## Proposed shape
+
+What are we doing?
+
+## Alternatives considered
+
+What did we reject and why?
+
+## Specs to create or update
+
+- <REPO>-SPEC-...
+
+## Architecture decisions needed
+
+- <REPO>-ADR-...
+
+## Implementation campaign shape
+
+High-level PR phases. Do not put the full PR queue here.
+
+## Evidence plan
+
+Proof commands, fixtures, receipts, support-tier updates, CI lanes, or policy ledgers.
+
+## Risks
+
+What can go wrong?
+
+## Non-goals
+
+What is explicitly out of scope?
+
+## Exit criteria
+
+When is this proposal done?

--- a/.rails/templates/spec.md
+++ b/.rails/templates/spec.md
@@ -1,0 +1,52 @@
+# <REPO>-SPEC-0001: <Title>
+
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked lane:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Problem
+
+What behavior or contract gap exists?
+
+## Behavior
+
+What must be true?
+
+## Non-goals
+
+What is explicitly out of scope?
+
+## Required evidence
+
+What proof is required?
+
+## Acceptance examples
+
+Concrete examples. Prefer user-visible examples, fixture names, receipt shapes, or CLI output.
+
+## Test mapping
+
+Which tests, fixtures, snapshots, receipts, golden files, or reports cover this?
+
+## Implementation mapping
+
+Which crates, modules, commands, workflows, or APIs own this?
+
+## CI proof
+
+Which commands and CI lanes prove it?
+
+## Metrics / promotion rule
+
+What moves this from experimental to stabilizing or stable?
+
+## Failure modes
+
+What must not silently pass?

--- a/.rails/templates/support-claim.md
+++ b/.rails/templates/support-claim.md
@@ -1,0 +1,20 @@
+# Support claim: <claim-id>
+
+Claim:
+Surface:
+Tier:
+Owner:
+
+## User-facing statement
+
+What users may believe.
+
+## Proof mapping
+
+- command:
+- artifact:
+- receipt:
+
+## Review cadence
+
+How often this claim is revalidated.

--- a/.rails/templates/work-item.md
+++ b/.rails/templates/work-item.md
@@ -1,0 +1,26 @@
+# Work item: <work-item-id>
+
+Status:
+Owner:
+Lane:
+Proposal:
+Spec:
+ADR:
+
+## Goal
+
+What this work item makes true.
+
+## Scope
+
+What is included and excluded.
+
+## Steps
+
+- [ ] Step 1
+- [ ] Step 2
+
+## Proof
+
+- command:
+- expected evidence:

--- a/docs/contributing/rails.md
+++ b/docs/contributing/rails.md
@@ -1,0 +1,20 @@
+# Contributing to Rails artifacts
+
+When adding or updating Rails artifacts in this repository:
+
+1. Keep durable framework state under `.rails/`.
+2. Keep human-facing explanation docs under `docs/`.
+3. Link all owned artifacts through `.rails/index.toml`.
+4. Use focused lane trackers under `.rails/lanes/` instead of a global active queue.
+5. Keep external namespaces awareness-only (`.codex/`, `.spec/`, `.claude/`, `.jules/`).
+
+## Do not mutate external namespaces
+
+This lane does not migrate, rewrite, or validate:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+Those directories can be referenced in `.rails/index.toml` as external namespaces only.

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -1,0 +1,23 @@
+# Rails framework footprint
+
+This repository uses `.rails/` as the durable Rails knowledge base.
+
+## Ownership model
+
+- `.rails/` is the durable Rails knowledge base.
+- `docs/` explains Rails conventions and adoption to humans.
+- `.codex/` is Codex execution state and is not owned by Rails.
+- `.spec/` is Spec Kit / speckit state and is not owned by Rails.
+- `.claude/` and `.jules/` are external agent/session spaces and are not owned by Rails.
+
+## Artifact model
+
+Rails artifacts are linked through `.rails/index.toml`.
+
+- proposals describe why work exists.
+- specs describe required behavior and evidence.
+- ADRs capture durable architecture decisions.
+- lanes provide focused implementation trackers.
+- closeouts record what shipped, what proved it, and what remains.
+
+No Rails-owned artifact path may live under `.codex/`, `.spec/`, `.claude/`, or `.jules/`.


### PR DESCRIPTION
### Motivation

- Establish a durable, repo-native Rails knowledge base under `.rails/` so long-lived proposals, specs, ADRs, lanes, templates, and closeouts have a single portable footprint. 
- Keep agent/tool execution state (e.g. `.codex/`, `.spec/`, `.claude/`, `.jules/`) awareness-only and out of durable ownership to avoid coupling long-lived truth to tool state.

### Description

- Add `.rails/` with `README.md`, `index.toml`, a templates suite, and subdirectories for `proposals`, `specs`, `adr`, `lanes`, `templates`, `closeouts`, `support`, `policy`, `receipts`, and `schemas`.
- Add human-facing docs `docs/rails.md` and `docs/contributing/rails.md` that describe ownership, artifact model, and contributor guidance.
- Add initial indexed artifacts and lane: `DSWARM-PROP-0001` (proposal), `DSWARM-SPEC-0001` (spec), `DSWARM-ADR-0001` (ADR), plus `.rails/lanes/rails-adoption/` with `tracker.toml` and `implementation-plan.md`.
- Add templates for `proposal.md`, `spec.md`, `adr.md`, `lane-tracker.toml`, `implementation-plan.md`, `work-item.md`, `support-claim.md`, `policy-reference.toml`, and `closeout.md`; do not modify any `.codex/`, `.spec/`, `.claude/`, or `.jules/` files.

### Testing

- Ran `git diff --check` to validate repository formatting and found no blocking errors.
- Verified repository state with `git status --short` to confirm the new files are present and staged.
- Performed local index and file inspections to ensure `.rails/index.toml` entries resolve to the new artifact paths (manual checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed6eaf0148333b770ddafa4f971a9)