### PR TITLE
Add self-hosted runner routing guard and wire into Pack CI

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Validate agent prompts
         run: python scripts/validate_agent_prompts.py
 
+      - name: Check self-hosted runner routing
+        run: bash scripts/check-no-bare-self-hosted.sh
+
   pack-check:
     # Windows CI catches platform-specific path handling and bash compatibility issues
     strategy:

--- a/scripts/check-no-bare-self-hosted.sh
+++ b/scripts/check-no-bare-self-hosted.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bad=0
+workflow_dir=".github/workflows"
+
+echo "Checking for bare self-hosted runner usage..."
+
+if [ ! -d "$workflow_dir" ]; then
+  echo "No GitHub workflow directory found; skipping self-hosted runner routing guard."
+  exit 0
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required for the self-hosted runner routing guard." >&2
+  exit 2
+fi
+
+inline_matches="$(rg -n --glob '*.yml' --glob '*.yaml' 'runs-on:[[:space:]]*\[[^]]*self-hosted[^]]*linux[^]]*x64[^]]*\]' "$workflow_dir" || true)"
+if [ -n "$inline_matches" ]; then
+  printf '%s\n' "$inline_matches"
+  echo "Bare inline self-hosted/linux/x64 runs-on is forbidden." >&2
+  bad=1
+fi
+
+while IFS=: read -r file line _; do
+  [ -n "${file:-}" ] || continue
+  window="$(sed -n "${line},$((line + 16))p" "$file")"
+
+  if printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*linux[[:space:]]*$' &&
+     printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*x64[[:space:]]*$' &&
+     ! printf '%s\n' "$window" | rg -q 'group:[[:space:]]*em-ci-' &&
+     ! printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*(em-ci|ci-nano|policy-nano|workflow-nano|rust-tiny|rust-medium|rust-large|rust-16gb|cx23|cx33|cx43|cx53|cpx42)[[:space:]]*$'; then
+    echo "$file:$line: bare self-hosted block lacks group/capacity labels" >&2
+    bad=1
+  fi
+done < <(rg -n --glob '*.yml' --glob '*.yaml' '^[[:space:]]*-[[:space:]]*self-hosted[[:space:]]*$' "$workflow_dir" || true)
+
+exit "$bad"


### PR DESCRIPTION
### Motivation
- Prevent workflows from accidentally using bare `self-hosted/linux/x64` runner blocks and enforce explicit `em-ci` group/capacity labels so jobs route to the intended runner pools.

### Description
- Add `scripts/check-no-bare-self-hosted.sh`, a guard that rejects inline `runs-on: [self-hosted, linux, x64]` and flags multiline self-hosted blocks without `em-ci` group/capacity labels.
- Wire the guard into the existing `lint` job in `.github/workflows/pack.yml` so routing regressions are checked automatically on push and PR.
- The guard requires `rg` (ripgrep) at runtime and scans YAML workflow files under `.github/workflows` across the repo.
- Commit recorded as "Add self-hosted runner routing guard" and the new script is executable.

### Testing
- Ran `bash scripts/check-no-bare-self-hosted.sh` and the guard completed without error on the repository workflows.
- Ran `ruby -e 'require "psych"; Psych.load_file(...)' .github/workflows/pack.yml` to validate YAML parsing and it succeeded.
- Ran `bash -n scripts/check-no-bare-self-hosted.sh && python scripts/validate_agent_prompts.py && python scripts/lint_frontmatter.py` and all checks completed (agent prompt validation passed with non-blocking warnings and frontmatter lint passed).
- Performed `git diff --check` and `git diff --cached --check` to ensure no whitespace/YAML issues and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c179010b48333ae03d47b6222bce0)