### PR TITLE
Add Droid PR Review workflow using MiniMax-M3 BYOK

### DIFF
--- a/.github/workflows/droid-pr-review.yml
+++ b/.github/workflows/droid-pr-review.yml
@@ -1,0 +1,59 @@
+name: Droid PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: droid-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Configure MiniMax M3 for Droid BYOK
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.factory"
+
+          cat > "$HOME/.factory/settings.json" <<'JSON'
+          {
+            "customModels": [
+              {
+                "model": "MiniMax-M3",
+                "displayName": "MiniMax-M3",
+                "baseUrl": "https://api.minimax.io/anthropic",
+                "apiKey": "${MINIMAX_API_KEY}",
+                "provider": "anthropic",
+                "maxOutputTokens": 64000
+              }
+            ]
+          }
+          JSON
+
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ""
+          ANTHROPIC_BASE_URL: ""
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          review_model: custom:MiniMax-M3-0
+          automatic_security_review: true
+          security_model: custom:MiniMax-M3-0


### PR DESCRIPTION
### Motivation
- Provide an automated, non-interactive Droid PR review job that uses the MiniMax M3 model via Factory BYOK to run deterministic reviews in CI. 
- Allow teams to pin the review and security models to a predictable `custom:MiniMax-M3-0` custom model id so Droid Exec and the action use the MiniMax Token Plan key. 

### Description
- Add a new GitHub Actions workflow at `.github/workflows/droid-pr-review.yml` that triggers on PR open/synchronize/reopen/ready-for-review events and skips draft PRs. 
- At runtime the job writes `~/.factory/settings.json` with a `customModels` entry for `MiniMax-M3` using the Anthropic-compatible base URL `https://api.minimax.io/anthropic` and the `${MINIMAX_API_KEY}` placeholder. 
- The workflow invokes `Factory-AI/droid-action@main` with `automatic_review: true`, `automatic_security_review: true`, and explicitly passes `review_model: custom:MiniMax-M3-0` and `security_model: custom:MiniMax-M3-0`, while clearing `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` environment variables. 
- The job includes a per-PR concurrency group and minimal permissions required for posting reviews. 

### Testing
- Parsed the workflow YAML using Ruby (`YAML.load_file`) which succeeded. 
- Performed a shell syntax check of the generated BYOK step script with `bash -n /tmp/droid-byok-step.sh` which succeeded. 
- Attempted to parse the workflow with a Python `yaml` invocation which failed due to the environment missing the `yaml` module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d09d14fd08333bcb9300542888dcc)